### PR TITLE
Fix StringRef editor

### DIFF
--- a/src/org/infinity/datatype/StringRef.java
+++ b/src/org/infinity/datatype/StringRef.java
@@ -252,11 +252,7 @@ public final class StringRef extends Datatype implements Editable, IsNumeric, Is
   @Override
   public boolean updateValue(AbstractStruct struct)
   {
-    final int newvalue = getValueFromEditor();
-    String newstring = StringTable.getStringRef(newvalue);
-    if (newstring.equalsIgnoreCase("Error"))
-      return false;
-    value = newvalue;
+    value = getValueFromEditor();
 
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));


### PR DESCRIPTION
* Replace text field for entry number with numerical field which fixes `NumberFormatException` if enter in the field not a number (first commit)
* Fix error that prevents from selection string with value `Error` in `dialog.tlk` for StringRef field (second commit)
![emptystringref](https://user-images.githubusercontent.com/450131/45921975-3835d480-beda-11e8-8f21-5430041b4d94.PNG)
