### PR TITLE
Display localized names of the areas, creatures, items, spells and stores in the main navigation tree

### DIFF
--- a/src/org/infinity/gui/ResourceTree.java
+++ b/src/org/infinity/gui/ResourceTree.java
@@ -754,13 +754,19 @@ public final class ResourceTree extends JPanel implements TreeSelectionListener,
     public Component getTreeCellRendererComponent(JTree tree, Object o, boolean sel, boolean expanded,
                                                   boolean leaf, int row, boolean hasFocus)
     {
+      super.getTreeCellRendererComponent(tree, o, sel, expanded, leaf, row, hasFocus);
       if (leaf && o instanceof ResourceEntry) {
-        super.getTreeCellRendererComponent(tree, o, sel, expanded, leaf, row, hasFocus);
-        setIcon(((ResourceEntry)o).getIcon());
-        return this;
+        final ResourceEntry e = (ResourceEntry)o;
+        final String name  = e.getResourceName();
+        final String title = e.getSearchString();
+        //TODO: refactor code and remove "No such index" comparison
+        // Now getSearchString returns that string when StringRef index not found
+        // in the talk table
+        final boolean hasTitle = title != null && !title.isEmpty() && !"No such index".equals(title);
+        setText(hasTitle ? name + " - " + title : name);
+        setIcon(e.getIcon());
       }
-      else
-        return super.getTreeCellRendererComponent(tree, o, sel, expanded, leaf, row, hasFocus);
+      return this;
     }
   }
 }

--- a/src/org/infinity/resource/are/AreResource.java
+++ b/src/org/infinity/resource/are/AreResource.java
@@ -133,6 +133,14 @@ public final class AreResource extends AbstractStruct implements Resource, HasAd
   private StructHexViewer hexViewer;
   private AreaViewer areaViewer;
 
+  /**
+   * Retrivies localized name of the area from {@code mapname.2da} resource. If such
+   * resource does not exists, or not contains mapping for the specified area, returns
+   * {@code null}.
+   *
+   * @param entry Pointer to ARE resource. If {@code null}, method returns {@code null}
+   * @return String with localized name of the area from male talk table
+   */
   public static String getSearchString(ResourceEntry entry)
   {
     String retVal = null;

--- a/src/org/infinity/resource/key/ResourceEntry.java
+++ b/src/org/infinity/resource/key/ResourceEntry.java
@@ -196,7 +196,7 @@ public abstract class ResourceEntry implements Comparable<ResourceEntry>
           try (InputStream is = getResourceDataAsStream()) {
             searchString = StoResource.getSearchString(is);
           }
-        } else if (extension.equalsIgnoreCase("ARE") && Profile.isEnhancedEdition()) {
+        } else if (extension.equalsIgnoreCase("ARE")) {
           searchString = AreResource.getSearchString(this);
         }
       } catch (Exception e) {


### PR DESCRIPTION
I check that it works in games:
- Planescape: Torment
- Baldurs Gate: Tales of the Sword Coast
- Baldurs Gate II
- Icewind Dale: Heart of Winter
- Icewind Dale: Enhanced Edition
- Icewind Dale II

Screenshot for PST:

![names](https://user-images.githubusercontent.com/450131/47266836-474d8800-d555-11e8-8af4-452b2b945c99.png)
