### PR TITLE
Synchronize tree structure when properties of the state/transition changed

### DIFF
--- a/src/org/infinity/datatype/Bitmap.java
+++ b/src/org/infinity/datatype/Bitmap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -27,6 +27,19 @@ import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.Misc;
 
+/**
+ * Field that represents an integer enumeration of some values.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code int}</li>
+ * <li>Value meaning: value of the enumeration</li>
+ * </ul>
+ */
 public class Bitmap extends Datatype implements Editable, IsNumeric
 {
   private final String[] table;
@@ -108,12 +121,7 @@ public class Bitmap extends Datatype implements Editable, IsNumeric
   public boolean updateValue(AbstractStruct struct)
   {
     // updating value
-    final String svalue = list.getSelectedValue();
-    value = 0;
-    //FIXME: Ineffective code
-    while (!svalue.equals(toString(value))) {
-      value++;
-    }
+    setValue(calcValue());
 
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
@@ -190,18 +198,37 @@ public class Bitmap extends Datatype implements Editable, IsNumeric
     return null;
   }
 
-  // Returns a formatted description of the specified value.
+  /** Returns a formatted description of the specified value. */
   private String toString(int nr)
   {
     if (nr >= table.length) {
       return "Unknown (" + nr + ')';
     } else if (nr < 0) {
       return "Error (" + nr + ')';
-    } else if (table[nr] == null || table[nr].equals("")) {
+    } else if (table[nr] == null || table[nr].isEmpty()) {
       return "Unknown (" + nr + ')';
     } else {
       return table[nr] + " (" + nr + ')';
     }
   }
-}
 
+  private void setValue(int newValue)
+  {
+    final int oldValue = value;
+    value = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
+  }
+
+  private int calcValue()
+  {
+    final String svalue = list.getSelectedValue();
+    int val = 0;
+    //FIXME: Ineffective code
+    while (!svalue.equals(toString(val))) {
+      val++;
+    }
+    return val;
+  }
+}

--- a/src/org/infinity/datatype/ColorPicker.java
+++ b/src/org/infinity/datatype/ColorPicker.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -39,7 +39,19 @@ import org.infinity.resource.graphics.ColorConvert;
 import org.infinity.util.Misc;
 
 
-/** Implements a RGB color picker control. */
+/**
+ * Implements a RGB color picker control.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code int}</li>
+ * <li>Value meaning: components of the color in format determined by field</li>
+ * </ul>
+ */
 public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseListener, FocusListener
 {
   /** Supported color formats. */
@@ -276,7 +288,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
   @Override
   public boolean updateValue(AbstractStruct struct)
   {
-    value = getInputRgbValue();
+    setValue(getInputRgbValue());
 
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
@@ -444,6 +456,15 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
 
 //--------------------- End Interface IsNumeric ---------------------
 
+  private void setValue(int newValue)
+  {
+    final int oldValue = value;
+    value = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
+  }
+
   // r, g, b in range [0..255]
   private int getRgbValue(int r, int g, int b)
   {
@@ -475,7 +496,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     return (color >>> shiftBlue) & 0xff;
   }
 
-  // Returns a color value based on the RGB input fields
+  /** Returns a color value based on the RGB input fields. */
   private int getInputRgbValue() throws NumberFormatException
   {
     return getRgbValue(getInputRed(), getInputGreen(), getInputBlue());
@@ -502,7 +523,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     return v;
   }
 
-  // Checks and returns either the number fetched from the input field or oldVal on error
+  /** Checks and returns either the number fetched from the input field or oldVal on error. */
   private int validateNumberInput(JTextField tf, int oldVal, int min, int max)
   {
     if (tf != null) {
@@ -516,7 +537,10 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     return oldVal;
   }
 
-  // Returns color value based on the main preview coordinates and the saturation value from the input field
+  /**
+   * Returns color value based on the main preview coordinates and the saturation
+   * value from the input field.
+   */
   private void updateMainPreviewValue(int x, int y)
   {
     if (x < 0) x = 0; else if (x >= rcMainPreview.getWidth()) x = rcMainPreview.getWidth() - 1;
@@ -525,7 +549,10 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     tmpBri = 100 - (y * 100 / rcMainPreview.getHeight());
   }
 
-  // Returns color value based on the secondary preview coordinate and the hue/brightness values from the input fields
+  /**
+   * Returns color value based on the secondary preview coordinate and the
+   * hue/brightness values from the input fields.
+   */
   private void updateSecondPreviewValue(int y)
   {
     if (y < 0) y = 0; else if (y >= rcSecondPreview.getHeight()) y = rcSecondPreview.getHeight() - 1;
@@ -534,7 +561,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
 
   private void updateRgbFromHsb()
   {
-    Color c = new Color(Color.HSBtoRGB((float)tmpHue / 360.0f, (float)tmpSat / 100.0f, (float)tmpBri / 100.0f));
+    Color c = new Color(Color.HSBtoRGB(tmpHue / 360.0f, tmpSat / 100.0f, tmpBri / 100.0f));
     tmpRed = c.getRed();
     tmpGreen = c.getGreen();
     tmpBlue = c.getBlue();
@@ -544,12 +571,12 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
   {
     float[] hsb = {0.0f, 0.0f, 0.0f};
     Color.RGBtoHSB(tmpRed, tmpGreen, tmpBlue, hsb);
-    tmpHue = (int)Math.round(hsb[0]*360.0f);
-    tmpSat = (int)Math.round(hsb[1]*100.0f);
-    tmpBri = (int)Math.round(hsb[2]*100.0f);
+    tmpHue = Math.round(hsb[0]*360.0f);
+    tmpSat = Math.round(hsb[1]*100.0f);
+    tmpBri = Math.round(hsb[2]*100.0f);
   }
 
-  // Updates all temporary values for each color component
+  /** Updates all temporary values for each color component. */
   private void updateColorValues(int value)
   {
     tmpRed = getRed(value);
@@ -558,7 +585,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     updateHsbFromRgb();
   }
 
-  // Update RGB input controls only
+  /** Update RGB input controls only. */
   private void updateInputRgb()
   {
     tfRed.setText(Integer.toString(tmpRed));
@@ -569,7 +596,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     if (tfBlue.hasFocus()) tfBlue.selectAll();
   }
 
-  // Update HSB input controls only
+  /** Update HSB input controls only. */
   private void updateInputHsb()
   {
     tfHue.setText(Integer.toString(tmpHue));
@@ -580,7 +607,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     if (tfBri.hasFocus()) tfBri.selectAll();
   }
 
-  // Update preview controls only
+  /** Update preview controls only. */
   private void updatePreview()
   {
     // update main preview
@@ -593,7 +620,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     updateColorPreview();
   }
 
-  // Update controls with given color value
+  /** Update controls with given color value. */
   private void updateColor()
   {
     updateInputRgb();
@@ -601,7 +628,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     updatePreview();
   }
 
-  // Update main (hue/brightness) preview
+  /** Update main (hue/brightness) preview. */
   private void updateMainPreview()
   {
     // drawing background
@@ -629,7 +656,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     rcMainPreview.repaint();
   }
 
-  // Update secondary (saturation) preview
+  /** Update secondary (saturation) preview. */
   private void updateSecondPreview()
   {
     BufferedImage image = (BufferedImage)rcSecondPreview.getImage();
@@ -657,7 +684,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     rcSecondPreview.repaint();
   }
 
-  // Update color preview box
+  /** Update color preview box. */
   private void updateColorPreview()
   {
     BufferedImage image = (BufferedImage)rcColorPreview.getImage();
@@ -672,7 +699,7 @@ public class ColorPicker extends Datatype implements Editable, IsNumeric, MouseL
     rcColorPreview.repaint();
   }
 
-  // Update main preview background map
+  /** Update main preview background map. */
   private void initMainPreviewMap()
   {
     BufferedImage image = (BufferedImage)rcMainPreview.getImage();

--- a/src/org/infinity/datatype/ColorValue.java
+++ b/src/org/infinity/datatype/ColorValue.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -61,6 +61,19 @@ import org.infinity.util.Misc;
 import org.infinity.util.Table2da;
 import org.infinity.util.Table2daCache;
 
+/**
+ * Field that represents indexed color or color range.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code int}</li>
+ * <li>Value meaning: index of the color in the color table</li>
+ * </ul>
+ */
 public class ColorValue extends Datatype implements Editable, IsNumeric
 {
   private static final int DEFAULT_COLOR_WIDTH  = 16;
@@ -100,82 +113,82 @@ public class ColorValue extends Datatype implements Editable, IsNumeric
 
 //--------------------- Begin Interface Editable ---------------------
 
- @Override
- public JComponent edit(ActionListener container)
- {
-   int defaultColorWidth = (colorEntry == null) ? DEFAULT_COLOR_WIDTH : 0;
-   colorList = new JList<Image>(new ColorListModel(defaultColorWidth, DEFAULT_COLOR_HEIGHT, colorEntry));
-   colorList.setCellRenderer(new ColorCellRenderer(colorMap));
-   colorList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-   colorList.setBorder(BorderFactory.createLineBorder(Color.GRAY));
-   colorList.addMouseListener(new MouseAdapter() {
-     @Override
-     public void mouseClicked(MouseEvent event)
-     {
-       if (event.getClickCount() == 2) {
-         container.actionPerformed(new ActionEvent(this, 0, StructViewer.UPDATE_VALUE));
-       }
-     }
-   });
-   colorList.addKeyListener(new KeyAdapter() {
-     @Override
-     public void keyPressed(KeyEvent event)
-     {
-       if (event.getKeyCode() == KeyEvent.VK_ENTER) {
-         container.actionPerformed(new ActionEvent(this, 0, StructViewer.UPDATE_VALUE));
-       }
-     }
-   });
-   JScrollPane scroll = new JScrollPane(colorList);
-   scroll.setBorder(BorderFactory.createEmptyBorder());
+  @Override
+  public JComponent edit(ActionListener container)
+  {
+    int defaultColorWidth = (colorEntry == null) ? DEFAULT_COLOR_WIDTH : 0;
+    colorList = new JList<>(new ColorListModel(defaultColorWidth, DEFAULT_COLOR_HEIGHT, colorEntry));
+    colorList.setCellRenderer(new ColorCellRenderer(colorMap));
+    colorList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    colorList.setBorder(BorderFactory.createLineBorder(Color.GRAY));
+    colorList.addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseClicked(MouseEvent event)
+      {
+        if (event.getClickCount() == 2) {
+          container.actionPerformed(new ActionEvent(this, 0, StructViewer.UPDATE_VALUE));
+        }
+      }
+    });
+    colorList.addKeyListener(new KeyAdapter() {
+      @Override
+      public void keyPressed(KeyEvent event)
+      {
+        if (event.getKeyCode() == KeyEvent.VK_ENTER) {
+          container.actionPerformed(new ActionEvent(this, 0, StructViewer.UPDATE_VALUE));
+        }
+      }
+    });
+    JScrollPane scroll = new JScrollPane(colorList);
+    scroll.setBorder(BorderFactory.createEmptyBorder());
 
-   int selection = Math.min(colorList.getModel().getSize(), Math.max(0, getValue()));
-   colorList.setSelectedIndex(selection);
+    int selection = Math.min(colorList.getModel().getSize(), Math.max(0, getValue()));
+    colorList.setSelectedIndex(selection);
 
-   JButton bUpdate = new JButton("Update value", Icons.getIcon(Icons.ICON_REFRESH_16));
-   bUpdate.addActionListener(container);
-   bUpdate.setActionCommand(StructViewer.UPDATE_VALUE);
+    JButton bUpdate = new JButton("Update value", Icons.getIcon(Icons.ICON_REFRESH_16));
+    bUpdate.addActionListener(container);
+    bUpdate.setActionCommand(StructViewer.UPDATE_VALUE);
 
-   JPanel panel = new JPanel(new GridBagLayout());
+    JPanel panel = new JPanel(new GridBagLayout());
 
-   GridBagConstraints gbc = new GridBagConstraints();
-   gbc = ViewerUtil.setGBC(gbc, 0, 0, 1, 1, 1.0, 1.0, GridBagConstraints.CENTER,
-                           GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0);
-   panel.add(scroll, gbc);
+    GridBagConstraints gbc = new GridBagConstraints();
+    gbc = ViewerUtil.setGBC(gbc, 0, 0, 1, 1, 1.0, 1.0, GridBagConstraints.CENTER,
+                            GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0);
+    panel.add(scroll, gbc);
 
-   gbc = ViewerUtil.setGBC(gbc, 1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER,
-                           GridBagConstraints.NONE, new Insets(0, 8, 0, 0), 0, 0);
-   panel.add(bUpdate, gbc);
+    gbc = ViewerUtil.setGBC(gbc, 1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.CENTER,
+                            GridBagConstraints.NONE, new Insets(0, 8, 0, 0), 0, 0);
+    panel.add(bUpdate, gbc);
 
-   Dimension dim = (colorMap != null) ? new Dimension(DIM_MEDIUM.width + 100, DIM_MEDIUM.height) : DIM_MEDIUM;
-   panel.setMinimumSize(Misc.getScaledDimension(dim));
-   panel.setPreferredSize(Misc.getScaledDimension(dim));
+    Dimension dim = (colorMap != null) ? new Dimension(DIM_MEDIUM.width + 100, DIM_MEDIUM.height) : DIM_MEDIUM;
+    panel.setMinimumSize(Misc.getScaledDimension(dim));
+    panel.setPreferredSize(Misc.getScaledDimension(dim));
 
-   return panel;
- }
+    return panel;
+  }
 
- @Override
- public void select()
- {
-   colorList.ensureIndexIsVisible(colorList.getSelectedIndex());
- }
+  @Override
+  public void select()
+  {
+    colorList.ensureIndexIsVisible(colorList.getSelectedIndex());
+  }
 
- @Override
- public boolean updateValue(AbstractStruct struct)
- {
-   if (colorList.getSelectedIndex() >= 0) {
-     if (number != colorList.getSelectedIndex()) {
-       number = colorList.getSelectedIndex();
+  @Override
+  public boolean updateValue(AbstractStruct struct)
+  {
+    if (colorList.getSelectedIndex() >= 0) {
+      if (number != colorList.getSelectedIndex()) {
+        setValue(colorList.getSelectedIndex());
 
-       // notifying listeners
-       fireValueUpdated(new UpdateEvent(this, struct));
-     }
+        // notifying listeners
+        fireValueUpdated(new UpdateEvent(this, struct));
+      }
 
-     return true;
-   }
+      return true;
+    }
 
-   return false;
- }
+    return false;
+  }
 
 //--------------------- Begin Interface Writeable ---------------------
 
@@ -255,6 +268,15 @@ public class ColorValue extends Datatype implements Editable, IsNumeric
       }
     }
     return retVal;
+  }
+
+  private void setValue(int newValue)
+  {
+    final int oldValue = number;
+    number = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
   }
 
 //-------------------------- INNER CLASSES --------------------------

--- a/src/org/infinity/datatype/Datatype.java
+++ b/src/org/infinity/datatype/Datatype.java
@@ -1,10 +1,11 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
 
 import java.awt.Dimension;
+import java.beans.PropertyChangeEvent;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -13,10 +14,26 @@ import java.util.List;
 
 import javax.swing.event.EventListenerList;
 
+import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.io.ByteBufferOutputStream;
 import org.infinity.util.io.StreamUtils;
 
+/**
+ * Base class for all types of fields. Supplies base properties for fields: its
+ * name (not stored in the file), offset in the resource at which it starts and
+ * length in bytes in the resource.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: <i>depends of subclass</i></li>
+ * <li>Value meaning: <i>depends of subclass</i></li>
+ * </ul>
+ */
 public abstract class Datatype implements StructEntry
 {
   protected static final Dimension DIM_WIDE = new Dimension(800, 100);
@@ -195,6 +212,20 @@ public abstract class Datatype implements StructEntry
     }
   }
 
+  /**
+   * If parent of this datatype is {@link AbstractStruct} then generates event
+   * that describe change in this object. Property name in generated event
+   * is {@link #getName()} and owner is {@link #parent}.
+   *
+   * @param oldValue Old value of this object
+   * @param newValue Old value of this object
+   */
+  protected void firePropertyChange(Object oldValue, Object newValue)
+  {
+    if (parent instanceof AbstractStruct) {
+      ((AbstractStruct)parent).propertyChange(new PropertyChangeEvent(parent, getName(), oldValue, newValue));
+    }
+  }
 
   void writeInt(OutputStream os, int value) throws IOException
   {
@@ -222,4 +253,3 @@ public abstract class Datatype implements StructEntry
     writeInt(os, (int)value);
   }
 }
-

--- a/src/org/infinity/datatype/DecNumber.java
+++ b/src/org/infinity/datatype/DecNumber.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -11,6 +11,19 @@ import java.util.Locale;
 
 import org.infinity.resource.StructEntry;
 
+/**
+ * Field that represents numerical value which is usually edited in a decimal mode.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code long}</li>
+ * <li>Value meaning: numerical value of this field</li>
+ * </ul>
+ */
 public class DecNumber extends Datatype implements InlineEditable, IsNumeric
 {
   private long number;
@@ -34,7 +47,6 @@ public class DecNumber extends Datatype implements InlineEditable, IsNumeric
   public DecNumber(StructEntry parent, ByteBuffer buffer, int offset, int length, String name, boolean signed)
   {
     super(parent, offset, length, name);
-    this.number = 0L;
     this.signed = signed;
     read(buffer, offset);
   }
@@ -45,7 +57,7 @@ public class DecNumber extends Datatype implements InlineEditable, IsNumeric
   public boolean update(Object value)
   {
     try {
-      number = parseNumber(value, getSize(), signed, true);
+      setValue(parseNumber(value, getSize(), signed, true));
       return true;
     } catch (Exception e) {
       e.printStackTrace();
@@ -121,12 +133,16 @@ public class DecNumber extends Datatype implements InlineEditable, IsNumeric
 
   public void incValue(long value)
   {
-    number += value;
+    setValue(number + value);
   }
 
-  public void setValue(long value)
+  public void setValue(long newValue)
   {
-    number = value;
+    final long oldValue = number;
+    number = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
   }
 
   @Override
@@ -160,4 +176,3 @@ public class DecNumber extends Datatype implements InlineEditable, IsNumeric
     return newNumber;
   }
 }
-

--- a/src/org/infinity/datatype/Editable.java
+++ b/src/org/infinity/datatype/Editable.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -8,9 +8,15 @@ import java.awt.event.ActionListener;
 
 import javax.swing.JComponent;
 
+import org.infinity.gui.StructViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.StructEntry;
 
+/**
+ * Interface for fields that editable via external dialog, and not via inline editor
+ * in the {@link StructViewer}. For inline editing {@link Datatype datatype} must
+ * implement the {@link InlineEditable} interface.
+ */
 public interface Editable extends StructEntry
 {
   /**
@@ -33,4 +39,3 @@ public interface Editable extends StructEntry
    */
   boolean updateValue(AbstractStruct struct);
 }
-

--- a/src/org/infinity/datatype/Flag.java
+++ b/src/org/infinity/datatype/Flag.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -26,6 +26,19 @@ import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.Misc;
 
+/**
+ * Field that represents several numerical values as flags.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code long}</li>
+ * <li>Value meaning: the set flags of this field</li>
+ * </ul>
+ */
 public class Flag extends Datatype implements Editable, IsNumeric, ActionListener
 {
   public static final String DESC_NONE = "No flags set";
@@ -178,12 +191,7 @@ public class Flag extends Datatype implements Editable, IsNumeric, ActionListene
   public boolean updateValue(AbstractStruct struct)
   {
     // updating value
-    value = 0L;
-    for (int i = 0; i < checkBoxes.length; i++)
-      if (checkBoxes[i].isSelected()) {
-        setFlag(i);
-      }
-
+    setValue(calcValue());
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
 
@@ -276,22 +284,31 @@ public class Flag extends Datatype implements Editable, IsNumeric, ActionListene
 
   public void setValue(long newValue)
   {
+    final long oldValue = value;
     value = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
   }
 
-  private void setFlag(int i)
+  private long calcValue()
   {
-    long mask = 1L << i;
-    value |= mask;
+    long val = 0L;
+    for (int i = 0; i < checkBoxes.length; ++i) {
+      if (checkBoxes[i].isSelected()) {
+        val |= (1L << i);
+      }
+    }
+    return val;
   }
 
-  // Sets description for empty flags
+  /** Sets description for empty flags. */
   protected void setEmptyDesc(String desc)
   {
     nodesc = (desc != null) ? desc : DESC_NONE;
   }
 
-  // Sets labels and optional tooltips for each flag
+  /** Sets labels and optional tooltips for each flag. */
   protected void setFlagDescriptions(int size, String[] stable, int startOfs, char separator)
   {
     table = new String[8*size];
@@ -318,4 +335,3 @@ public class Flag extends Datatype implements Editable, IsNumeric, ActionListene
     }
   }
 }
-

--- a/src/org/infinity/datatype/FloatNumber.java
+++ b/src/org/infinity/datatype/FloatNumber.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -11,7 +11,20 @@ import java.nio.ByteBuffer;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.io.StreamUtils;
 
-
+/**
+ * Field that represents numerical value which is usually edited in a floating
+ * point mode.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code double}</li>
+ * <li>Value meaning: numerical value of this field</li>
+ * </ul>
+ */
 public class FloatNumber extends Datatype implements InlineEditable
 {
   private double value;
@@ -24,27 +37,26 @@ public class FloatNumber extends Datatype implements InlineEditable
   public FloatNumber(StructEntry parent, ByteBuffer buffer, int offset, int length, String name)
   {
     super(parent, offset, length, name);
-    value = 0.0;
     read(buffer, offset);
   }
 
 //--------------------- Begin Interface InlineEditable ---------------------
 
- @Override
- public boolean update(Object value)
- {
-   try {
-     double newValue = Double.parseDouble(value.toString());
-     if (getSize() == 4) {
-       newValue = Double.valueOf(newValue).floatValue();
-     }
-     this.value = newValue;
-     return true;
-   } catch (NumberFormatException e) {
-     e.printStackTrace();
-   }
-   return false;
- }
+  @Override
+  public boolean update(Object value)
+  {
+    try {
+      double newValue = Double.parseDouble(value.toString());
+      if (getSize() == 4) {
+        newValue = Double.valueOf(newValue).floatValue();
+      }
+      setValue(newValue);
+      return true;
+    } catch (NumberFormatException e) {
+      e.printStackTrace();
+    }
+    return false;
+  }
 
 //--------------------- End Interface InlineEditable ---------------------
 
@@ -88,8 +100,16 @@ public class FloatNumber extends Datatype implements InlineEditable
     return value;
   }
 
+  private void setValue(double newValue)
+  {
+    final double oldValue = value;
+    value = newValue;
+    if (Double.compare(oldValue, newValue) != 0) {
+      firePropertyChange(oldValue, newValue);
+    }
+  }
 
-  // Converts byte array of specified length into a double value
+  /** Converts byte array of specified length into a double value. */
   private static double toFloatNumber(ByteBuffer buffer, int offset, int length)
   {
     if (length == 4 || length == 8) {
@@ -104,7 +124,7 @@ public class FloatNumber extends Datatype implements InlineEditable
     return 0.0;
   }
 
-  // Converts double value into byte array of specified length
+  /** Converts double value into byte array of specified length. */
   private static ByteBuffer toByteBuffer(double value, int length)
   {
     if (length == 4 || length == 8) {

--- a/src/org/infinity/datatype/HashBitmap.java
+++ b/src/org/infinity/datatype/HashBitmap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -32,7 +32,20 @@ import org.infinity.util.LongIntegerHashMap;
 import org.infinity.util.Misc;
 import org.infinity.util.ObjectString;
 
-public class HashBitmap extends Datatype implements Editable, IsNumeric
+/**
+ * Field that represents an integer enumeration of some values.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code long}</li>
+ * <li>Value meaning: numerical value of this field</li>
+ * </ul>
+ */
+public class HashBitmap extends Datatype implements Editable, IsNumeric//TODO: try to unify with Bitmap
 {
   private final LongIntegerHashMap<? extends Object> idsmap;
   private final List<JButton> buttonList;
@@ -163,7 +176,7 @@ public class HashBitmap extends Datatype implements Editable, IsNumeric
     // updating value
     Long number = getValueOfItem(list.getSelectedValue());
     if (number != null) {
-      value = number.longValue();
+      setValue(number.longValue());
     } else {
       return false;
     }
@@ -240,7 +253,11 @@ public class HashBitmap extends Datatype implements Editable, IsNumeric
 
   protected void setValue(long newValue)
   {
+    final long oldValue = value;
     this.value = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
   }
 
   /** Called whenever the user selects a new list item. */
@@ -354,4 +371,3 @@ public class HashBitmap extends Datatype implements Editable, IsNumeric
     }
   }
 }
-

--- a/src/org/infinity/datatype/MultiNumber.java
+++ b/src/org/infinity/datatype/MultiNumber.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -33,6 +33,16 @@ import org.infinity.util.Misc;
 
 /**
  * A Number object consisting of multiple values of a given number of bits.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code int}</li>
+ * <li>Value meaning: OR'ed values of each individual subfield of this field</li>
+ * </ul>
  */
 public class MultiNumber extends Datatype implements Editable, IsNumeric
 {
@@ -172,7 +182,7 @@ public class MultiNumber extends Datatype implements Editable, IsNumeric
   @Override
   public boolean updateValue(AbstractStruct struct)
   {
-    value = mValues.getValue();
+    setValueImpl(mValues.getValue());
 
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
@@ -290,14 +300,14 @@ public class MultiNumber extends Datatype implements Editable, IsNumeric
   public void setValue(int value)
   {
     mValues.setValue(value);
-    this.value = mValues.getValue();
+    setValueImpl(mValues.getValue());
   }
 
   /** Sets the specified value. */
   public void setValue(int idx, int value)
   {
     mValues.setValue(idx, value);
-    this.value = mValues.getValue();
+    setValueImpl(mValues.getValue());
   }
 
   /**
@@ -315,6 +325,15 @@ public class MultiNumber extends Datatype implements Editable, IsNumeric
       retVal |= -1 & ~((1 << bits) - 1);
     }
     return retVal;
+  }
+
+  private void setValueImpl(int newValue)
+  {
+    final int oldValue = value;
+    value = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
   }
 
 //-------------------------- INNER CLASSES --------------------------

--- a/src/org/infinity/datatype/ResourceBitmap.java
+++ b/src/org/infinity/datatype/ResourceBitmap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -37,6 +37,16 @@ import org.infinity.util.Misc;
 
 /**
  * Datatype for selecting resource entries, constructed from a predefined list of key/value pairs.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code long}</li>
+ * <li>Value meaning: index of the resource in the predefined list</li>
+ * </ul>
  */
 public class ResourceBitmap extends Datatype
     implements Editable, IsNumeric, IsReference, ActionListener, ListSelectionListener
@@ -207,7 +217,7 @@ public class ResourceBitmap extends Datatype
       return false;
     }
 
-    value = selected.getValue();
+    setValue(selected.getValue());
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
 
@@ -317,6 +327,15 @@ public class ResourceBitmap extends Datatype
       }
     }
     return null;
+  }
+
+  private void setValue(long newValue)
+  {
+    final long oldValue = value;
+    value = newValue;
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
   }
 
 //-------------------------- INNER CLASSES --------------------------

--- a/src/org/infinity/datatype/StringRef.java
+++ b/src/org/infinity/datatype/StringRef.java
@@ -11,6 +11,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -42,6 +43,16 @@ import org.infinity.util.StringTable;
 /**
  * A struct field that represents reference to string in a talk table file (dialog.tlk
  * or dialogF.tlk).
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code int}</li>
+ * <li>Value meaning: number of the string in the TLK</li>
+ * </ul>
  */
 public final class StringRef extends Datatype implements Editable, IsNumeric, IsTextual, ActionListener, ChangeListener
 {
@@ -248,7 +259,7 @@ public final class StringRef extends Datatype implements Editable, IsNumeric, Is
   @Override
   public boolean updateValue(AbstractStruct struct)
   {
-    value = getValueFromEditor();
+    setValue(getValueFromEditor());
 
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
@@ -322,12 +333,17 @@ public final class StringRef extends Datatype implements Editable, IsNumeric, Is
 
 //--------------------- End Interface IsTextual ---------------------
 
-  public void setValue(int newvalue)
+  public void setValue(int newValue)
   {
-    value = newvalue;
-    taRefText.setText(StringTable.getStringRef(value));
-    sRefNr.setValue(value);
-    enablePlay(value);
+    final int oldValue = value;
+    value = newValue;
+    taRefText.setText(StringTable.getStringRef(newValue));
+    sRefNr.setValue(newValue);
+    enablePlay(newValue);
+
+    if (oldValue != newValue) {
+      firePropertyChange(oldValue, newValue);
+    }
   }
 
   /**

--- a/src/org/infinity/datatype/TextBitmap.java
+++ b/src/org/infinity/datatype/TextBitmap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -27,6 +28,19 @@ import org.infinity.resource.StructEntry;
 import org.infinity.util.Misc;
 import org.infinity.util.io.StreamUtils;
 
+/**
+ * Field that represents a string enumeration of some values.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@link String}</li>
+ * <li>Value meaning: value from list of enumarated values</li>
+ * </ul>
+ */
 public final class TextBitmap extends Datatype implements Editable, IsTextual
 {
   private final String[] ids;
@@ -122,7 +136,7 @@ public final class TextBitmap extends Datatype implements Editable, IsTextual
     if (index == -1) {
       return false;
     }
-    text = ids[index];
+    setValue(ids[index]);
 
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
@@ -200,6 +214,15 @@ public final class TextBitmap extends Datatype implements Editable, IsTextual
     return "";
   }
 
+  private void setValue(String newValue)
+  {
+    final String oldValue = text;
+    text = newValue;
+    if (!Objects.equals(oldValue, newValue)) {
+      firePropertyChange(oldValue, newValue);
+    }
+  }
+
 // -------------------------- INNER CLASSES --------------------------
 
   private final class BitmapTableModel extends AbstractTableModel
@@ -229,4 +252,3 @@ public final class TextBitmap extends Datatype implements Editable, IsTextual
     }
   }
 }
-

--- a/src/org/infinity/datatype/TextEdit.java
+++ b/src/org/infinity/datatype/TextEdit.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.EnumMap;
+import java.util.Objects;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -32,6 +33,16 @@ import org.infinity.resource.StructEntry;
 import org.infinity.util.Misc;
 import org.infinity.util.io.StreamUtils;
 
+/**
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@link String}</li>
+ * </ul>
+ */
 public final class TextEdit extends Datatype implements Editable, IsTextual
 {
   public static enum EOLType {
@@ -157,7 +168,7 @@ public final class TextEdit extends Datatype implements Editable, IsTextual
   @Override
   public boolean updateValue(AbstractStruct struct)
   {
-    text = textArea.getText();
+    setValue(textArea.getText());
 
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
@@ -292,6 +303,14 @@ public final class TextEdit extends Datatype implements Editable, IsTextual
       return s;
   }
 
+  private void setValue(String newValue)
+  {
+    final String oldValue = getText();
+    text = newValue;
+    if (!Objects.equals(oldValue, newValue)) {
+      firePropertyChange(oldValue, newValue);
+    }
+  }
 
 //-------------------------- INNER CLASSES --------------------------
 

--- a/src/org/infinity/datatype/TextString.java
+++ b/src/org/infinity/datatype/TextString.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -8,12 +8,26 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.Objects;
 
 import org.infinity.gui.BrowserMenuBar;
 import org.infinity.resource.StructEntry;
 import org.infinity.util.Misc;
 import org.infinity.util.io.StreamUtils;
 
+/**
+ * Field that represents string value in global editor encoding.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@link String}</li>
+ * <li>Value meaning: text value of the field</li>
+ * </ul>
+ */
 public final class TextString extends Datatype implements InlineEditable, IsTextual
 {
   private final Charset charset;
@@ -39,9 +53,10 @@ public final class TextString extends Datatype implements InlineEditable, IsText
   public boolean update(Object value)
   {
     String newstring = (String)value;
-    if (newstring.length() > getSize())
+    if (newstring.length() > getSize()) {
       return false;
-    text = newstring;
+    }
+    setValue(newstring);
     return true;
   }
 
@@ -99,5 +114,13 @@ public final class TextString extends Datatype implements InlineEditable, IsText
   {
     return getText();
   }
-}
 
+  private void setValue(String newValue)
+  {
+    final String oldValue = getText();
+    text = newValue;
+    if (!Objects.equals(oldValue, newValue)) {
+      firePropertyChange(oldValue, newValue);
+    }
+  }
+}

--- a/src/org/infinity/datatype/UnknownBinary.java
+++ b/src/org/infinity/datatype/UnknownBinary.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -9,6 +9,19 @@ import java.nio.ByteBuffer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.StructEntry;
 
+/**
+ * Field that represents binary data in binary format in their editor.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code byte[]}</li>
+ * <li>Value meaning: raw bytes of this field</li>
+ * </ul>
+ */
 public final class UnknownBinary extends Unknown
 {
   public UnknownBinary(ByteBuffer buffer, int offset, int length, String name)
@@ -26,27 +39,11 @@ public final class UnknownBinary extends Unknown
   @Override
   public boolean updateValue(AbstractStruct struct)
   {
-    String value = textArea.getText().trim();
-    value = value.replaceAll("\r?\n", " ");
-    int index = value.indexOf((int)' ');
-    while (index != -1) {
-      value = value.substring(0, index) + value.substring(index + 1);
-      index = value.indexOf((int)' ');
-    }
-    if (value.length() != 8 * buffer.limit()) {
+    final byte[] newData = calcValue(8, 2);
+    if (newData == null) {
       return false;
     }
-    byte newdata[] = new byte[buffer.limit()];
-    for (int i = 0; i < newdata.length; i++) {
-      String bytechars = value.substring(8 * i, 8 * i + 8);
-      try {
-        newdata[i] = (byte)Integer.parseInt(bytechars, 2);
-      } catch (NumberFormatException e) {
-        return false;
-      }
-    }
-    buffer.position(0);
-    buffer.put(newdata);
+    setValue(newData);
     return true;
   }
 
@@ -72,4 +69,3 @@ public final class UnknownBinary extends Unknown
       return "";
   }
 }
-

--- a/src/org/infinity/datatype/UnknownDecimal.java
+++ b/src/org/infinity/datatype/UnknownDecimal.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -9,6 +9,19 @@ import java.nio.ByteBuffer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.StructEntry;
 
+/**
+ * Field that represents binary data in decimal format in their editor.
+ *
+ * <h2>Bean property</h2>
+ * When this field is child of {@link AbstractStruct}, then changes of its internal
+ * value reported as {@link PropertyChangeEvent}s of the {@link #getParent() parent}
+ * struct.
+ * <ul>
+ * <li>Property name: {@link #getName() name} of this field</li>
+ * <li>Property type: {@code byte[]}</li>
+ * <li>Value meaning: raw bytes of this field</li>
+ * </ul>
+ */
 public final class UnknownDecimal extends Unknown
 {
   public UnknownDecimal(ByteBuffer buffer, int offset, int length, String name)
@@ -43,8 +56,7 @@ public final class UnknownDecimal extends Unknown
         index = value.indexOf((int)' ');
       }
       if (counter == newdata.length) {
-        buffer.position(0);
-        buffer.put(newdata);
+        setValue(newdata);
         return true;
       }
     } catch (NumberFormatException e) {
@@ -75,4 +87,3 @@ public final class UnknownDecimal extends Unknown
       return "";
   }
 }
-

--- a/src/org/infinity/resource/dlg/AbstractCode.java
+++ b/src/org/infinity/resource/dlg/AbstractCode.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedSet;
 
 import javax.swing.JButton;
@@ -235,11 +236,11 @@ public abstract class AbstractCode extends Datatype
     JButton bUpdate = (JButton)buttonPanel.getControlByType(CtrlUpdate);
     if (bCheck.isEnabled())
       bCheck.doClick();
-    if (errors.size() > 0) {
+    if (!errors.isEmpty()) {
       String options[] = {"Update", "Cancel"};
       if (JOptionPane.showOptionDialog(textArea.getTopLevelAncestor(), "Errors exist. Update anyway?", "Update value",
                                        JOptionPane.YES_NO_OPTION,
-                                       JOptionPane.WARNING_MESSAGE, null, options, options[0]) != 0) {
+                                       JOptionPane.WARNING_MESSAGE, null, options, options[0]) != JOptionPane.YES_OPTION) {
 
         // notifying listeners
         fireValueUpdated(new UpdateEvent(this, struct));
@@ -247,14 +248,15 @@ public abstract class AbstractCode extends Datatype
         return true;
       }
     }
-    text = textArea.getText();
-    int index = text.indexOf((int)'\n');
+    String text = textArea.getText();
+    int index = text.indexOf('\n');
     while (index != -1) {
       text = text.substring(0, index) + '\r' + text.substring(index);
-      index = text.indexOf((int)'\n', index + 2);
+      index = text.indexOf('\n', index + 2);
     }
     bUpdate.setEnabled(false);
 
+    setValue(text);
     // notifying listeners
     fireValueUpdated(new UpdateEvent(this, struct));
 
@@ -380,5 +382,13 @@ public abstract class AbstractCode extends Datatype
     textArea.select(startpos, endpos);
     textArea.getCaret().setSelectionVisible(true);
   }
-}
 
+  private void setValue(String newValue)
+  {
+    final String oldValue = getText();
+    text = newValue;
+    if (!Objects.equals(oldValue, newValue)) {
+      firePropertyChange(oldValue, newValue);
+    }
+  }
+}

--- a/src/org/infinity/resource/dlg/BrokenReference.java
+++ b/src/org/infinity/resource/dlg/BrokenReference.java
@@ -1,0 +1,13 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.dlg;
+
+/**
+ * Marker interface that implemented by classes, that represent broken elements
+ * in visual dialog tree.
+ *
+ * @author Mingun
+ */
+interface BrokenReference {}

--- a/src/org/infinity/resource/dlg/BrokenStateItem.java
+++ b/src/org/infinity/resource/dlg/BrokenStateItem.java
@@ -1,0 +1,47 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.dlg;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+
+import org.infinity.icon.Icons;
+
+/**
+ * Encapsulates a broken dialog state reference - this state is referenced from
+ * some transition, but state is absent in dialogue file.
+ *
+ * @author Mingun
+ */
+class BrokenStateItem extends StateItem implements BrokenReference
+{
+  private static final ImageIcon ICON = Icons.getIcon(Icons.ICON_WARNING_16);
+
+  /** Dialog which contains non-existent state. */
+  private final DlgResource dlg;
+  /** Number of non-existent state. */
+  private final int number;
+  public BrokenStateItem(DlgResource dlg, int number, StateOwnerItem parent)
+  {
+    super(parent);
+    this.dlg = dlg;
+    this.number = number;
+  }
+
+  @Override
+  public DlgResource getDialog() { return dlg; }
+
+  @Override
+  public Icon getIcon() { return ICON; }
+
+  @Override
+  public boolean getAllowsChildren() { return false; }
+
+  @Override
+  public String getName() { return "State " + number; }
+
+  @Override
+  public String toString() { return getName() + ": <Broken reference, state not exist>"; }
+}

--- a/src/org/infinity/resource/dlg/BrokenTransitionItem.java
+++ b/src/org/infinity/resource/dlg/BrokenTransitionItem.java
@@ -1,0 +1,44 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.dlg;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+
+import org.infinity.icon.Icons;
+
+/**
+ * Encapsulates a broken dialog transition reference - reference to which some
+ * state refers, but which is absent in dialogue file.
+ *
+ * @author Mingun
+ */
+final class BrokenTransitionItem extends TransitionItem implements BrokenReference
+{
+  private static final ImageIcon ICON = Icons.getIcon(Icons.ICON_WARNING_16);
+
+  /** Number of non-existent response. */
+  private final int number;
+  public BrokenTransitionItem(int number, StateItem parent)
+  {
+    super(parent);
+    this.number = number;
+  }
+
+  @Override
+  public DlgResource getDialog() { return parent.getDialog(); }
+
+  @Override
+  public Icon getIcon() { return ICON; }
+
+  @Override
+  public boolean getAllowsChildren() { return false; }
+
+  @Override
+  public String getName() { return "Response " + number; }
+
+  @Override
+  public String toString() { return getName() + ": <Broken reference, response not exist>"; }
+}

--- a/src/org/infinity/resource/dlg/DlgTreeModel.java
+++ b/src/org/infinity/resource/dlg/DlgTreeModel.java
@@ -4,6 +4,8 @@
 
 package org.infinity.resource.dlg;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,7 +27,7 @@ import org.infinity.resource.ResourceFactory;
 import org.infinity.resource.StructEntry;
 
 /** Creates and manages the dialog tree structure. */
-final class DlgTreeModel implements TreeModel, TableModelListener
+final class DlgTreeModel implements TreeModel, TableModelListener, PropertyChangeListener
 {
   private final ArrayList<TreeModelListener> listeners = new ArrayList<>();
   /** Maps used dialog names to dialog resources. */
@@ -47,6 +49,7 @@ final class DlgTreeModel implements TreeModel, TableModelListener
       putItem(state, null);
     }
     dlg.addTableModelListener(this);
+    dlg.addPropertyChangeListener(this);
   }
 
   //<editor-fold defaultstate="collapsed" desc="TreeModel">
@@ -152,6 +155,58 @@ final class DlgTreeModel implements TreeModel, TableModelListener
   }
   //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="PropertyChangeListener">
+  @Override
+  public void propertyChange(PropertyChangeEvent e)
+  {
+    final Object src  = e.getSource();
+    final String prop = e.getPropertyName();
+    if (src instanceof TreeItemEntry) {
+      final List<ItemBase> items = allItems.get(src);
+      if (items == null) { return; }
+
+      // Count of responses changed
+      if (State.DLG_STATE_NUM_RESPONSES.equals(prop)) {
+        // Copy list since it can change during iteration
+        changeStateTransCount((State)src, new ArrayList<>(items), e.getOldValue(), e.getNewValue());
+      } else
+      // First response transition changed
+      if (State.DLG_STATE_FIRST_RESPONSE_INDEX.equals(prop)) {
+        // Copy list since it can change during iteration
+        changeStateFirstTrans((State)src, new ArrayList<>(items), e.getOldValue(), e.getNewValue());
+      } else
+      // Next dialog or next dialog state changed
+      if (Transition.DLG_TRANS_NEXT_DIALOG.equals(prop)
+       || Transition.DLG_TRANS_NEXT_DIALOG_STATE.equals(prop)
+      ) {
+        // Copy list since it can change during iteration
+        changeTransition(new ArrayList<>(items));
+      } else
+      // Transition flags changed
+      if (Transition.DLG_TRANS_FLAGS.equals(prop)) {
+        final int oldFlags = ((Number)e.getOldValue()).intValue();
+        final int newFlags = ((Number)e.getNewValue()).intValue();
+        final int diff = oldFlags ^ newFlags;
+
+        // Flag 3: Terminates dialogue - if changed, rebuild tree
+        if ((diff & (1 << 3)) != 0) {
+          // Copy list since it can change during iteration
+          changeTransition(new ArrayList<>(items));
+        } else
+        // Flag 0: Text associated - if changed, repaint nodes
+        // No need to repaint if flag 3 changed - it already repainted
+        if ((diff & (1 << 0)) != 0) {
+          items.forEach(this::nodeChanged);
+        }
+      } else
+      // Response text or Associated text changed
+      if (State.DLG_STATE_RESPONSE.equals(prop) || Transition.DLG_TRANS_TEXT.equals(prop)) {
+        items.forEach(this::nodeChanged);
+      }
+    }
+  }
+  //</editor-fold>
+
   //<editor-fold defaultstate="collapsed" desc="Events">
   /**
    * Updates tree when specified state or transition entry changed.
@@ -224,6 +279,93 @@ final class DlgTreeModel implements TreeModel, TableModelListener
 
   //<editor-fold defaultstate="collapsed" desc="State changed">
   /**
+   * Changes tree structure accourding to the changes in the
+   * {@link State#DLG_STATE_FIRST_RESPONSE_INDEX} property of the state.
+   * <p>
+   * Example:
+   * <code><pre>
+   * Transition indexes (start increased by 2):
+   *    oldValue: 3, cnt: 4 -> [3, 4, 5, 6]
+   *    newValue: 5, cnt: 4 -> [5, 6, 7, 8] -> remove [3, 4], insert [7, 8]
+   * Tree item child index:     0  1  2  3             0  1           2  3
+   *
+   * Transition indexes (start decreased by 2):
+   *    oldValue: 3, cnt: 4 -> [3, 4, 5, 6]
+   *    newValue: 1, cnt: 4 -> [1, 2, 3, 4] -> remove [5, 6], insert [1, 2]
+   * Tree item child index:     0  1  2  3             2  3           0  1
+   * </pre></code>
+   *
+   * @param state Changed state entry
+   * @param items List of visual items that represents state in the tree
+   * @param oldValue Old value of bound bean property
+   * @param newValue New value of bound bean property
+   */
+  private void changeStateFirstTrans(State state, List<ItemBase> items, Object oldValue, Object newValue)
+  {
+    final int cnt = state.getTransCount();
+    final int oldStart = ((Number)oldValue).intValue();
+    final int newStart = ((Number)newValue).intValue();
+    final int diff = newStart - oldStart;
+
+    if (diff > 0) {
+      for (ItemBase item : items) {
+        final StateItem s = (StateItem)item;
+        // If this not main state item and non-main items do not contains childs, skip
+        if (s.trans == null) continue;
+
+        removeChildTransitions(s, 0, diff);
+        insertChildTransitions(s, newStart, cnt - diff, cnt);
+      }
+    } else
+    if (diff < 0) {
+      for (ItemBase item : items) {
+        final StateItem s = (StateItem)item;
+        // If this not main state item and non-main items do not contains childs, skip
+        if (s.trans == null) continue;
+
+        removeChildTransitions(s, cnt + diff, cnt);
+        insertChildTransitions(s, newStart, 0, -diff);
+      }
+    }
+  }
+
+  /**
+   * Changes tree structure accourding to the changes in the
+   * {@link State#DLG_STATE_NUM_RESPONSES} property of the state. Appends
+   * or removes {@link TransitionItem}s based on the value of the bean property.
+   *
+   * @param state Changed state entry
+   * @param items List of visual items that represents state in the tree
+   * @param oldValue Old value of bound bean property
+   * @param newValue New value of bound bean property
+   */
+  private void changeStateTransCount(State state, List<ItemBase> items, Object oldValue, Object newValue)
+  {
+    final int start  = state.getFirstTrans();
+    final int oldCnt = ((Number)oldValue).intValue();
+    final int newCnt = ((Number)newValue).intValue();
+
+    if (newCnt > oldCnt) {
+      for (ItemBase item : items) {
+        final StateItem s = (StateItem)item;
+        // If this not main state item and non-main items do not contains childs, skip
+        if (s.trans == null) continue;
+
+        insertChildTransitions(s, start, oldCnt, newCnt);
+      }
+    } else
+    if (newCnt < oldCnt) {
+      for (ItemBase item : items) {
+        final StateItem s = (StateItem)item;
+        // If this not main state item and non-main items do not contains childs, skip
+        if (s.trans == null) continue;
+
+        removeChildTransitions(s, newCnt, oldCnt);
+      }
+    }
+  }
+
+  /**
    * Adds continuous range of tree items that represent transitions from specified
    * state and notifies listeners. If state is not main state and option
    * {@link BrowserMenuBar#breakCyclesInDialogs()} is enabled, do nothing.
@@ -271,6 +413,32 @@ final class DlgTreeModel implements TreeModel, TableModelListener
   }
   //</editor-fold>
 
+  //<editor-fold defaultstate="collapsed" desc="Transition changed">
+  /**
+   * Changes tree structure accourding to the changes in the
+   * {@link Transition#DLG_TRANS_NEXT_DIALOG},
+   * {@link Transition#DLG_TRANS_NEXT_DIALOG_STATE} or
+   * {@link Transition#DLG_TRANS_FLAGS} properties of the transition entry.
+   *
+   * Emits {@link TreeModelListener#treeStructureChanged} event for each element
+   * in {@code items}.
+   *
+   * @param items List of visual items that represents transition in the tree
+   */
+  private void changeTransition(List<ItemBase> items)
+  {
+    for (ItemBase item : items) {
+      final TransitionItem t = (TransitionItem)item;
+      if (t.nextState != null) {
+        removeItem(t.nextState);
+        t.nextState = null;
+      }
+      // New node, if required, will be created on demand
+      fireTreeStructureChanged(item.getPath());
+    }
+  }
+  //</editor-fold>
+
   //<editor-fold defaultstate="collapsed" desc="Event emitting">
   private void nodeChanged(ItemBase node)
   {
@@ -307,9 +475,18 @@ final class DlgTreeModel implements TreeModel, TableModelListener
   {
     if (!listeners.isEmpty()) {
       final TreeModelEvent event = new TreeModelEvent(this, path, childIndices, children);
-      for (int i = listeners.size()-1; i >= 0; i--) {
-        final TreeModelListener tml = listeners.get(i);
+      for (final TreeModelListener tml : listeners) {
         tml.treeNodesRemoved(event);
+      }
+    }
+  }
+
+  private void fireTreeStructureChanged(TreePath path)
+  {
+    if (!listeners.isEmpty()) {
+      final TreeModelEvent event = new TreeModelEvent(this, path);
+      for (final TreeModelListener tml : listeners) {
+        tml.treeStructureChanged(event);
       }
     }
   }

--- a/src/org/infinity/resource/dlg/DlgTreeModel.java
+++ b/src/org/infinity/resource/dlg/DlgTreeModel.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.IntStream;
 
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
@@ -19,6 +20,7 @@ import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 
 import org.infinity.datatype.ResourceRef;
+import org.infinity.gui.BrowserMenuBar;
 import org.infinity.resource.ResourceFactory;
 import org.infinity.resource.StructEntry;
 
@@ -190,6 +192,85 @@ final class DlgTreeModel implements TreeModel, TableModelListener
     }
   }
 
+  /**
+   * Removes visual sub-tree (including {@code item} itself) from tree model,
+   * notifies listeners about changes. Changes includes removal of nodes and
+   * changes in some non-main nodes (which a not a part of the deleted sub-tree),
+   * if among the deleted nodes there are main nodes. Does not change dialog tree
+   * entries - affects only GUI nodes.
+   *
+   * @param item Root of deleted sub-tree
+   */
+  private void removeItem(ItemBase item)
+  {
+    final TreeItemEntry entry = item.getEntry();
+    final List<ItemBase> items = allItems.get(entry);
+    if (items.remove(item)) {
+      // If element not exists in all items list it already deleted, so skip.
+      // This occurs when dialog has cycle and `item` is some item inside it
+      @SuppressWarnings("unchecked")
+      final MainRef<ItemBase> main = (MainRef<ItemBase>)mainItems.get(entry);
+      if (main != null && main.ref == item) {
+        if (items.isEmpty()) {
+          mainItems.remove(entry);
+        } else {
+          main.ref = items.get(0);
+          nodeChanged(main.ref);
+        }
+      }
+      item.traverseChildren(this::removeItem);
+    }
+  }
+
+  //<editor-fold defaultstate="collapsed" desc="State changed">
+  /**
+   * Adds continuous range of tree items that represent transitions from specified
+   * state and notifies listeners. If state is not main state and option
+   * {@link BrowserMenuBar#breakCyclesInDialogs()} is enabled, do nothing.
+   *
+   * @param parent Parent state under which tree items must be added
+   * @param startTransition First transition index that state has
+   * @param fromIndex Index of the first child tree item under {@code parent}
+   *        state to add, inclusive
+   * @param toIndex Index of the last child tree item under {@code parent}
+   *        state to add, exclusive
+   */
+  private void insertChildTransitions(StateItem parent, int startTransition, int fromIndex, int toIndex)
+  {
+    parent.trans.ensureCapacity(toIndex);
+    addTransitions(parent, startTransition + fromIndex, startTransition + toIndex);
+
+    final int[] childIndices = IntStream.range(fromIndex, toIndex).toArray();
+    final Object[] children  = parent.trans.subList(fromIndex, toIndex).toArray();
+
+    fireTreeNodesInserted(parent.getPath(), childIndices, children);
+  }
+
+  /**
+   * Removes all visual tree items under {@code parent} state and notifies listeners.
+   *
+   * @param parent Parent state at which tree items must be removed
+   * @param fromIndex Index of the first child tree item of the {@code state}
+   *        to remove, inclusive
+   * @param toIndex Index of the last child tree item of the {@code state}
+   *        to remove, exclusive
+   */
+  private void removeChildTransitions(StateItem parent, int fromIndex, int toIndex)
+  {
+    final List<TransitionItem> items = parent.trans.subList(fromIndex, toIndex);
+    final int[] childIndices = IntStream.range(fromIndex, toIndex).toArray();
+    final Object[] children  = items.toArray();
+
+    // Clear global registers and redirect main references
+    for (TransitionItem item : items) {
+      removeItem(item);
+    }
+
+    items.clear();
+    fireTreeNodesRemoved(parent.getPath(), childIndices, children);
+  }
+  //</editor-fold>
+
   //<editor-fold defaultstate="collapsed" desc="Event emitting">
   private void nodeChanged(ItemBase node)
   {
@@ -206,9 +287,18 @@ final class DlgTreeModel implements TreeModel, TableModelListener
   {
     if (!listeners.isEmpty()) {
       final TreeModelEvent event = new TreeModelEvent(this, path, childIndices, children);
-      for (int i = listeners.size()-1; i >= 0; i--) {
-        final TreeModelListener tml = listeners.get(i);
+      for (final TreeModelListener tml : listeners) {
         tml.treeNodesChanged(event);
+      }
+    }
+  }
+
+  private void fireTreeNodesInserted(TreePath path, int[] childIndices, Object[] children)
+  {
+    if (!listeners.isEmpty()) {
+      final TreeModelEvent event = new TreeModelEvent(this, path, childIndices, children);
+      for (final TreeModelListener tml : listeners) {
+        tml.treeNodesInserted(event);
       }
     }
   }
@@ -367,21 +457,35 @@ final class DlgTreeModel implements TreeModel, TableModelListener
   private void initState(StateItem state)
   {
     if (state.trans == null) {
-      final DlgResource dlg = state.getDialog();
       final int start = state.getEntry().getFirstTrans();
       final int count = state.getEntry().getTransCount();
 
       state.trans = new ArrayList<>(count);
-      for (int i = start; i < start + count; ++i) {
-        final Transition trans = dlg.getTransition(i);
-        if (trans != null) {
-          @SuppressWarnings("unchecked")
-          final MainRef<TransitionItem> main = (MainRef<TransitionItem>)mainItems.get(trans);
-          final TransitionItem item = new TransitionItem(trans, state, main);
+      addTransitions(state, start, start + count);
+    }
+  }
 
-          state.trans.add(item);
-          putItem(item, main);
-        }
+  /**
+   * Creates {@link TransitionItem}s for transitions at specified indexes.
+   *
+   * @param state State item for which need create additional transition tree items
+   * @param firstTransition Index of the first transition in the {@code state}
+   *        {@link StateItem#getDialog() dialog} that need to add, inclusive
+   * @param lastTransition Index of the last transition in the state dialog that
+   *        need to add, exclusive
+   */
+  private void addTransitions(StateItem state, int firstTransition, int lastTransition)
+  {
+    final DlgResource dlg = state.getDialog();
+    for (int i = firstTransition; i < lastTransition; ++i) {
+      final Transition trans = dlg.getTransition(i);
+      if (trans != null) {
+        @SuppressWarnings("unchecked")
+        final MainRef<TransitionItem> main = (MainRef<TransitionItem>)mainItems.get(trans);
+        final TransitionItem item = new TransitionItem(trans, state, main);
+
+        state.trans.add(item);
+        putItem(item, main);
       }
     }
   }

--- a/src/org/infinity/resource/dlg/ItemBase.java
+++ b/src/org/infinity/resource/dlg/ItemBase.java
@@ -5,6 +5,7 @@
 package org.infinity.resource.dlg;
 
 import java.util.Enumeration;
+import java.util.function.Consumer;
 
 import javax.swing.Icon;
 import javax.swing.tree.TreeNode;
@@ -72,6 +73,17 @@ abstract class ItemBase implements TreeNode
    * @return {@code true} if item is child of this node and was removed, {@code false} otherwize.
    */
   public abstract boolean removeChild(ItemBase child);
+
+  /**
+   * Performs the given action for each child of the node until all childrens have
+   * been processed or the action throws an exception. Exceptions thrown by the
+   * action are relayed to the caller.
+   *
+   * @param action The action to be performed for each children
+   *
+   * @throws NullPointerException If the specified action is {@code null}
+   */
+  public abstract void traverseChildren(Consumer<ItemBase> action);
 
   //<editor-fold defaultstate="collapsed" desc="TreeNode">
   @Override

--- a/src/org/infinity/resource/dlg/MainRef.java
+++ b/src/org/infinity/resource/dlg/MainRef.java
@@ -1,0 +1,29 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.dlg;
+
+/**
+ * Reference to the main item of the visual tree item. Storage of the reference
+ * to a main item indirectly, in this object, allows to replace quickly the main
+ * item object without the need for a traverse of all items which refer to it.
+ * It is required when the main visual node is removed from a tree, but other
+ * nodes, representing the same {@link TreeItemEntry}, still are available in a
+ * tree. At emergence of such situation as the one of such nodes will be chosen
+ * as new main item.
+ *
+ * @param <T> Type of reference to hold
+ *
+ * @author Mingun
+ */
+final class MainRef<T extends ItemBase>
+{
+  /** Actual reference to the main item. */
+  T ref;
+
+  public MainRef(T ref) { this.ref = ref; }
+
+  @Override
+  public String toString() { return ref.toString(); }
+}

--- a/src/org/infinity/resource/dlg/RootItem.java
+++ b/src/org/infinity/resource/dlg/RootItem.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import static java.util.Collections.enumeration;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.function.Consumer;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -80,6 +81,9 @@ final class RootItem extends StateOwnerItem implements Iterable<StateItem>
 
   @Override
   public boolean removeChild(ItemBase child) { return states.remove(child); }
+
+  @Override
+  public void traverseChildren(Consumer<ItemBase> action) { states.forEach(action); }
 
   //<editor-fold defaultstate="collapsed" desc="TreeNode">
   @Override

--- a/src/org/infinity/resource/dlg/State.java
+++ b/src/org/infinity/resource/dlg/State.java
@@ -34,9 +34,9 @@ public final class State extends AbstractStruct implements AddRemovable, TreeIte
     super(null, DLG_STATE, StreamUtils.getByteBuffer(16), 0);
   }
 
-  State(AbstractStruct superStruct, ByteBuffer buffer, int offset, int count) throws Exception
+  State(DlgResource dlg, ByteBuffer buffer, int offset, int count) throws Exception
   {
-    super(superStruct, DLG_STATE + " " + count, buffer, offset);
+    super(dlg, DLG_STATE + " " + count, buffer, offset);
     nr = count;
   }
 
@@ -49,6 +49,9 @@ public final class State extends AbstractStruct implements AddRemovable, TreeIte
   {
     return (StringRef)getAttribute(DLG_STATE_RESPONSE, false);
   }
+
+  @Override
+  public DlgResource getParent() { return (DlgResource)super.getParent(); }
   //</editor-fold>
 
   public int getFirstTrans()

--- a/src/org/infinity/resource/dlg/StateItem.java
+++ b/src/org/infinity/resource/dlg/StateItem.java
@@ -10,6 +10,7 @@ import static java.util.Collections.enumeration;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -56,6 +57,14 @@ final class StateItem extends ItemBase implements Iterable<TransitionItem>
 
   @Override
   public boolean removeChild(ItemBase child) { return trans.remove(child); }
+
+  @Override
+  public void traverseChildren(Consumer<ItemBase> action)
+  {
+    if (trans != null) {
+      trans.forEach(action);
+    }
+  }
 
   //<editor-fold defaultstate="collapsed" desc="TreeNode">
   @Override

--- a/src/org/infinity/resource/dlg/StateItem.java
+++ b/src/org/infinity/resource/dlg/StateItem.java
@@ -50,7 +50,7 @@ final class StateItem extends ItemBase implements Iterable<TransitionItem>
   public StateItem getMain() { return main == null || main.ref == this ? null : main.ref; }
 
   @Override
-  public DlgResource getDialog() { return (DlgResource)state.getParent(); }
+  public DlgResource getDialog() { return state.getParent(); }
 
   @Override
   public Icon getIcon() { return ICON; }

--- a/src/org/infinity/resource/dlg/StateItem.java
+++ b/src/org/infinity/resource/dlg/StateItem.java
@@ -29,13 +29,13 @@ final class StateItem extends ItemBase implements Iterable<TransitionItem>
   private final StateOwnerItem parent;
   /**
    * Item to which need go to in break cycles tree view mode. This item contains
-   * referense to the same state as this one (i.e. {@code this.state == main.state})
+   * referense to the same state as this one (i.e. {@code this.state == main.ref.state})
    */
-  private final StateItem main;
+  private final MainRef<StateItem> main;
   /** Items that represents transition tree nodes from this state. */
   ArrayList<TransitionItem> trans;
 
-  public StateItem(State state, StateOwnerItem parent, StateItem main)
+  public StateItem(State state, StateOwnerItem parent, MainRef<StateItem> main)
   {
     this.state  = Objects.requireNonNull(state,  "State dialog entry must be not null");
     this.parent = Objects.requireNonNull(parent, "Parent tree of state item must be not null");
@@ -46,7 +46,7 @@ final class StateItem extends ItemBase implements Iterable<TransitionItem>
   public State getEntry() { return state; }
 
   @Override
-  public StateItem getMain() { return main; }
+  public StateItem getMain() { return main == null || main.ref == this ? null : main.ref; }
 
   @Override
   public DlgResource getDialog() { return (DlgResource)state.getParent(); }

--- a/src/org/infinity/resource/dlg/StateItem.java
+++ b/src/org/infinity/resource/dlg/StateItem.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -20,14 +20,14 @@ import org.infinity.gui.BrowserMenuBar;
 import org.infinity.icon.Icons;
 
 /** Encapsulates a dialog state entry. */
-final class StateItem extends ItemBase implements Iterable<TransitionItem>
+class StateItem extends ItemBase implements Iterable<TransitionItem>
 {
   private static final ImageIcon ICON = Icons.getIcon(Icons.ICON_STOP_16);
 
   private final State state;
 
   /** Tree item that represent visual parent of this state in the tree. */
-  private final StateOwnerItem parent;
+  protected final StateOwnerItem parent;
   /**
    * Item to which need go to in break cycles tree view mode. This item contains
    * referense to the same state as this one (i.e. {@code this.state == main.ref.state})
@@ -36,6 +36,12 @@ final class StateItem extends ItemBase implements Iterable<TransitionItem>
   /** Items that represents transition tree nodes from this state. */
   ArrayList<TransitionItem> trans;
 
+  protected StateItem(StateOwnerItem parent)
+  {
+    this.state  = null;
+    this.parent = Objects.requireNonNull(parent, "Parent tree of broken state item must be not null");
+    this.main   = null;
+  }
   public StateItem(State state, StateOwnerItem parent, MainRef<StateItem> main)
   {
     this.state  = Objects.requireNonNull(state,  "State dialog entry must be not null");
@@ -65,6 +71,9 @@ final class StateItem extends ItemBase implements Iterable<TransitionItem>
       trans.forEach(action);
     }
   }
+
+  /** Returns technical name of state item which uniquely identifying it within dialog. */
+  public String getName() { return state.getName(); }
 
   //<editor-fold defaultstate="collapsed" desc="TreeNode">
   @Override

--- a/src/org/infinity/resource/dlg/Transition.java
+++ b/src/org/infinity/resource/dlg/Transition.java
@@ -40,9 +40,9 @@ public final class Transition extends AbstractStruct implements AddRemovable, Tr
     super(null, DLG_TRANS, StreamUtils.getByteBuffer(32), 0);
   }
 
-  Transition(AbstractStruct superStruct, ByteBuffer buffer, int offset, int nr) throws Exception
+  Transition(DlgResource dlg, ByteBuffer buffer, int offset, int nr) throws Exception
   {
-    super(superStruct, DLG_TRANS + " " + nr, buffer, offset);
+    super(dlg, DLG_TRANS + " " + nr, buffer, offset);
     this.nr = nr;
   }
 
@@ -56,7 +56,10 @@ public final class Transition extends AbstractStruct implements AddRemovable, Tr
   {
     return (StringRef)getAttribute(DLG_TRANS_TEXT, false);
   }
-//</editor-fold>
+
+  @Override
+  public DlgResource getParent() { return (DlgResource)super.getParent(); }
+  //</editor-fold>
 
   public int getActionIndex()
   {

--- a/src/org/infinity/resource/dlg/TransitionItem.java
+++ b/src/org/infinity/resource/dlg/TransitionItem.java
@@ -28,13 +28,13 @@ final class TransitionItem extends StateOwnerItem
   private final StateItem parent;
   /**
    * Item to which need go to in break cycles tree view mode. This item contains
-   * referense to the same transition as this one (i.e. {@code this.trans == main.trans})
+   * referense to the same transition as this one (i.e. {@code this.trans == main.ref.trans})
    */
-  private final TransitionItem main;
+  private final MainRef<TransitionItem> main;
   /** Tree item to which go this transition or {@code null}, if this transition terminates dialog. */
   StateItem nextState;
 
-  public TransitionItem(Transition trans, StateItem parent, TransitionItem main)
+  public TransitionItem(Transition trans, StateItem parent, MainRef<TransitionItem> main)
   {
     this.trans  = Objects.requireNonNull(trans,  "Transition dialog entry must be not null");
     this.parent = Objects.requireNonNull(parent, "Parent tree of transition item must be not null");
@@ -45,7 +45,7 @@ final class TransitionItem extends StateOwnerItem
   public Transition getEntry() { return trans; }
 
   @Override
-  public TransitionItem getMain() { return main; }
+  public TransitionItem getMain() { return main == null || main.ref == this ? null : main.ref; }
 
   @Override
   public DlgResource getDialog() { return (DlgResource)trans.getParent(); }

--- a/src/org/infinity/resource/dlg/TransitionItem.java
+++ b/src/org/infinity/resource/dlg/TransitionItem.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -19,14 +19,14 @@ import org.infinity.gui.BrowserMenuBar;
 import org.infinity.icon.Icons;
 
 /** Encapsulates a dialog transition entry. */
-final class TransitionItem extends StateOwnerItem
+class TransitionItem extends StateOwnerItem
 {
   private static final ImageIcon ICON = Icons.getIcon(Icons.ICON_PLAY_16);
 
   private final Transition trans;
 
   /** Parent tree item from which this transition is available. */
-  private final StateItem parent;
+  protected final StateItem parent;
   /**
    * Item to which need go to in break cycles tree view mode. This item contains
    * referense to the same transition as this one (i.e. {@code this.trans == main.ref.trans})
@@ -35,10 +35,16 @@ final class TransitionItem extends StateOwnerItem
   /** Tree item to which go this transition or {@code null}, if this transition terminates dialog. */
   StateItem nextState;
 
+  protected TransitionItem(StateItem parent)
+  {
+    this.trans  = null;
+    this.parent = Objects.requireNonNull(parent, "Parent state of broken transition item must be not null");
+    this.main   = null;
+  }
   public TransitionItem(Transition trans, StateItem parent, MainRef<TransitionItem> main)
   {
     this.trans  = Objects.requireNonNull(trans,  "Transition dialog entry must be not null");
-    this.parent = Objects.requireNonNull(parent, "Parent tree of transition item must be not null");
+    this.parent = Objects.requireNonNull(parent, "Parent state of transition item must be not null");
     this.main   = main;
   }
 
@@ -72,6 +78,9 @@ final class TransitionItem extends StateOwnerItem
     }
   }
 
+  /** Returns technical name of transition item which uniquely identifying it within dialog. */
+  public String getName() { return trans.getName(); }
+
   //<editor-fold defaultstate="collapsed" desc="TreeNode">
   @Override
   public StateItem getChildAt(int childIndex) { return isMain() && childIndex == 0 ? nextState : null; }
@@ -95,7 +104,7 @@ final class TransitionItem extends StateOwnerItem
   @Override
   public Enumeration<? extends StateItem> children()
   {
-    return enumeration(isLeaf() ?  emptyList(): singletonList(nextState));
+    return enumeration(isLeaf() ? emptyList() : singletonList(nextState));
   }
   //</editor-fold>
 

--- a/src/org/infinity/resource/dlg/TransitionItem.java
+++ b/src/org/infinity/resource/dlg/TransitionItem.java
@@ -49,7 +49,7 @@ final class TransitionItem extends StateOwnerItem
   public TransitionItem getMain() { return main == null || main.ref == this ? null : main.ref; }
 
   @Override
-  public DlgResource getDialog() { return (DlgResource)trans.getParent(); }
+  public DlgResource getDialog() { return trans.getParent(); }
 
   @Override
   public Icon getIcon() { return ICON; }

--- a/src/org/infinity/resource/dlg/TransitionItem.java
+++ b/src/org/infinity/resource/dlg/TransitionItem.java
@@ -9,6 +9,7 @@ import static java.util.Collections.enumeration;
 import static java.util.Collections.singletonList;
 import java.util.Enumeration;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -61,6 +62,14 @@ final class TransitionItem extends StateOwnerItem
       return true;
     }
     return false;
+  }
+
+  @Override
+  public void traverseChildren(Consumer<ItemBase> action)
+  {
+    if (nextState != null) {
+      action.accept(nextState);
+    }
   }
 
   //<editor-fold defaultstate="collapsed" desc="TreeNode">

--- a/src/org/infinity/resource/dlg/TreeItemEntry.java
+++ b/src/org/infinity/resource/dlg/TreeItemEntry.java
@@ -28,4 +28,7 @@ public interface TreeItemEntry extends StructEntry
    * @return Text for show or {@code null} if case of broken structure
    */
   StringRef getAssociatedText();
+
+  @Override
+  DlgResource getParent();
 }

--- a/src/org/infinity/resource/dlg/TreeViewer.java
+++ b/src/org/infinity/resource/dlg/TreeViewer.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -141,7 +141,8 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
           final Viewer tab = (Viewer)curDlg.getViewerTab(0);
           if (item instanceof RootItem) {
             viewer.selectEntry(0);
-          } else {
+          } else
+          if (!(item instanceof BrokenReference)) {
             final TreeItemEntry s = item.getEntry();
             viewer.selectEntry(s.getName());
             tab.select(s);
@@ -253,35 +254,42 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
   private void updateStateInfo(StateItem si)
   {
     final DlgResource curDlg = si.getDialog();
-    final State state = si.getEntry();
 
     // updating info box title
-    final StringBuilder sb = new StringBuilder(state.getName() + ", ");
+    final StringBuilder sb = new StringBuilder(si.getName());
     if (curDlg != dlg) {
-      sb.append(String.format("Dialog: %s, ", curDlg.getResourceEntry().getResourceName()));
+      sb.append(String.format(", Dialog: %s", curDlg.getResourceEntry().getResourceName()));
     }
-    sb.append(String.format("Responses: %d", state.getTransCount()));
-    if (state.getTriggerIndex() >= 0) {
-      sb.append(String.format(", Weight: %d", state.getTriggerIndex()));
-    }
-    dlgInfo.updateControlBorder(ItemInfo.Type.STATE, sb.toString());
 
-    final int strRef = state.getAssociatedText().getValue();
-    // updating state text
-    dlgInfo.showControl(ItemInfo.Type.STATE_TEXT, true);
-    dlgInfo.updateControlText(ItemInfo.Type.STATE_TEXT, StringTable.getStringRef(strRef));
+    final State state = si.getEntry();
+    if (state != null) {
+      sb.append(String.format(", Responses: %d", state.getTransCount()));
+      if (state.getTriggerIndex() >= 0) {
+        sb.append(String.format(", Weight: %d", state.getTriggerIndex()));
+      }
+      dlgInfo.updateControlBorder(ItemInfo.Type.STATE, sb.toString());
 
-    // updating state WAV Res
-    final String responseText = StringTable.getSoundResource(strRef);
-    if (!responseText.isEmpty()) {
-      dlgInfo.showControl(ItemInfo.Type.STATE_WAV, true);
-      dlgInfo.updateControlText(ItemInfo.Type.STATE_WAV, responseText + ".WAV");
+      final int strRef = state.getAssociatedText().getValue();
+      // updating state text
+      dlgInfo.showControl(ItemInfo.Type.STATE_TEXT, true);
+      dlgInfo.updateControlText(ItemInfo.Type.STATE_TEXT, StringTable.getStringRef(strRef));
+
+      // updating state WAV Res
+      final String responseText = StringTable.getSoundResource(strRef);
+      if (!responseText.isEmpty()) {
+        dlgInfo.showControl(ItemInfo.Type.STATE_WAV, true);
+        dlgInfo.updateControlText(ItemInfo.Type.STATE_WAV, responseText + ".WAV");
+      } else {
+        dlgInfo.showControl(ItemInfo.Type.STATE_WAV, false);
+      }
     } else {
+      dlgInfo.showControl(ItemInfo.Type.STATE_TEXT, false);
       dlgInfo.showControl(ItemInfo.Type.STATE_WAV, false);
+      dlgInfo.updateControlBorder(ItemInfo.Type.STATE, sb.toString());
     }
 
     // updating state triggers
-    if (state.getTriggerIndex() >= 0) {
+    if (state != null && state.getTriggerIndex() >= 0) {
       dlgInfo.showControl(ItemInfo.Type.STATE_TRIGGER, true);
       final StructEntry entry = curDlg.getAttribute(StateTrigger.DLG_STATETRIGGER + " " + state.getTriggerIndex());
       final String text = entry instanceof StateTrigger ? ((StateTrigger)entry).getText() : "";
@@ -299,21 +307,23 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
   private void updateTransitionInfo(TransitionItem ti)
   {
     final DlgResource curDlg = ti.getDialog();
-    final Transition trans = ti.getEntry();
 
     // updating info box title
-    final StringBuilder sb = new StringBuilder(trans.getName());
+    final StringBuilder sb = new StringBuilder(ti.getName());
     if (curDlg != dlg) {
       sb.append(String.format(", Dialog: %s", curDlg.getResourceEntry().getResourceName()));
     }
     dlgInfo.updateControlBorder(ItemInfo.Type.RESPONSE, sb.toString());
 
+    final Transition trans = ti.getEntry();
     // updating flags
-    dlgInfo.showControl(ItemInfo.Type.RESPONSE_FLAGS, true);
-    dlgInfo.updateControlText(ItemInfo.Type.RESPONSE_FLAGS, trans.getFlag().toString());
+    dlgInfo.showControl(ItemInfo.Type.RESPONSE_FLAGS, trans != null);
+    if (trans != null) {
+      dlgInfo.updateControlText(ItemInfo.Type.RESPONSE_FLAGS, trans.getFlag().toString());
+    }
 
     // updating response text
-    if (trans.getFlag().isFlagSet(0)) {
+    if (trans != null && trans.getFlag().isFlagSet(0)) {
       dlgInfo.showControl(ItemInfo.Type.RESPONSE_TEXT, true);
       dlgInfo.updateControlText(ItemInfo.Type.RESPONSE_TEXT,
                                 StringTable.getStringRef(trans.getAssociatedText().getValue()));
@@ -322,7 +332,7 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
     }
 
     // updating journal entry
-    if (trans.getFlag().isFlagSet(4)) {
+    if (trans != null && trans.getFlag().isFlagSet(4)) {
       dlgInfo.showControl(ItemInfo.Type.RESPONSE_JOURNAL, true);
       dlgInfo.updateControlText(ItemInfo.Type.RESPONSE_JOURNAL,
                                 StringTable.getStringRef(trans.getJournalEntry().getValue()));
@@ -331,7 +341,7 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
     }
 
     // updating response trigger
-    if (trans.getFlag().isFlagSet(1)) {
+    if (trans != null && trans.getFlag().isFlagSet(1)) {
       dlgInfo.showControl(ItemInfo.Type.RESPONSE_TRIGGER, true);
       final StructEntry entry = curDlg.getAttribute(ResponseTrigger.DLG_RESPONSETRIGGER + " " + trans.getTriggerIndex());
       final String text = entry instanceof ResponseTrigger ? ((ResponseTrigger)entry).getText() : "";
@@ -341,7 +351,7 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
     }
 
     // updating action
-    if (trans.getFlag().isFlagSet(2)) {
+    if (trans != null && trans.getFlag().isFlagSet(2)) {
       dlgInfo.showControl(ItemInfo.Type.RESPONSE_ACTION, true);
       final StructEntry entry = curDlg.getAttribute(Action.DLG_ACTION + " " + trans.getActionIndex());
       final String text = entry instanceof Action ? ((Action)entry).getText() : "";
@@ -425,6 +435,9 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
           setForeground(Color.BLUE);
         }
 
+        if (value instanceof BrokenReference) {
+          setForeground(Color.RED);// Broken reference
+        } else
         if (value instanceof StateItem) {
           final StateItem state = (StateItem)value;
           final State s = state.getEntry();
@@ -504,7 +517,7 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
           dlgTree.setSelectionPath(path);
           final boolean isNonRoot = path != null && path.getPathCount() > 1;
 
-          miEditEntry.setEnabled(path != null);
+          miEditEntry.setEnabled(path != null && !(path.getLastPathComponent() instanceof BrokenReference));
           miExpand.setEnabled(isNonRoot && !isNodeExpanded(path));
           miCollapse.setEnabled(isNonRoot && !isNodeCollapsed(path));
 

--- a/src/org/infinity/resource/dlg/TreeWorker.java
+++ b/src/org/infinity/resource/dlg/TreeWorker.java
@@ -100,7 +100,6 @@ class TreeWorker extends SwingWorker<Void, Void>
   /** Collapses all children and their children of the given path. */
   private void collapseNode(final TreePath path)
   {
-    System.err.println("collapse: "+path);
     if (progress.isCanceled()) return;
     advanceProgress();
 


### PR DESCRIPTION
This PR the first in the chain leading to implementation (almost) full-fledged editor of dialog from a tree. It solves the first problem -- synchronization of information in a tree with information in the flat entry list. It does not process adding and removals of entries -- for this purpose it is necessary to fix bug #100 first since because of it after the first removal the internal structure breaks and it is impossible to make with dialog anything else.

If you want to check that nothing is valid is forgotten, and all collections are cleaned from unnecessary nodes, I prepared a special branch with the debug code which I used for debugging -- https://github.com/Mingun/NearInfinity/tree/debug-synchronize-tree.