### PR TITLE
Add debug helper with ability to print to stdout current resource/class/field

### DIFF
--- a/src/org/infinity/NearInfinity.java
+++ b/src/org/infinity/NearInfinity.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2018 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity;
@@ -12,6 +12,7 @@ import java.awt.Font;
 import java.awt.Frame;
 import java.awt.Image;
 import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.dnd.DnDConstants;
@@ -289,10 +290,12 @@ public final class NearInfinity extends JFrame implements ActionListener, Viewab
     globalFontSize = Math.max(50, Math.min(400, prefs.getInt(OPTION_GLOBAL_FONT_SIZE, 100)));
     resizeUIFont(globalFontSize);
 
-    new BrowserMenuBar();
-    setJMenuBar(BrowserMenuBar.getInstance());
+    final BrowserMenuBar menu = new BrowserMenuBar();
+    // Registers menu as key event dispatcher to intercept Ctrl+Shift+D from any window
+    KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(menu);
+    setJMenuBar(menu);
 
-    String lastDir = null;
+    final String lastDir;
     if (gameOverride != null && Files.isDirectory(gameOverride)) {
       lastDir = gameOverride.toString();
     } else {
@@ -1117,4 +1120,3 @@ public final class NearInfinity extends JFrame implements ActionListener, Viewab
     }
   }
 }
-

--- a/src/org/infinity/gui/BrowserMenuBar.java
+++ b/src/org/infinity/gui/BrowserMenuBar.java
@@ -10,11 +10,14 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
+import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.KeyEventDispatcher;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
+import static java.awt.event.ActionEvent.SHIFT_MASK;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
@@ -73,10 +76,14 @@ import org.infinity.gui.converter.ConvertToMos;
 import org.infinity.gui.converter.ConvertToPvrz;
 import org.infinity.gui.converter.ConvertToTis;
 import org.infinity.icon.Icons;
+import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.Profile;
 import org.infinity.resource.Resource;
 import org.infinity.resource.ResourceFactory;
+import org.infinity.resource.StructEntry;
 import org.infinity.resource.StructureFactory;
+import org.infinity.resource.Viewable;
+import org.infinity.resource.ViewableContainer;
 import org.infinity.resource.key.FileResourceEntry;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.resource.text.PlainTextResource;
@@ -96,7 +103,7 @@ import org.infinity.util.Pair;
 import org.infinity.util.StringTable;
 import org.infinity.util.io.FileManager;
 
-public final class BrowserMenuBar extends JMenuBar
+public final class BrowserMenuBar extends JMenuBar implements KeyEventDispatcher
 {
   public static final String VERSION = "v2.1-20180615";
   public static final int OVERRIDE_IN_THREE = 0, OVERRIDE_IN_OVERRIDE = 1, OVERRIDE_SPLIT = 2;
@@ -504,6 +511,65 @@ public final class BrowserMenuBar extends JMenuBar
     gameMenu.storePreferences();
   }
 
+  //<editor-fold defaultstate="collapsed" desc="Debug helpers">
+  @Override
+  public boolean dispatchKeyEvent(KeyEvent e)
+  {
+    final KeyStroke acc = toolsMenu.dumpDebugInfo.getAccelerator();
+    if (!e.isConsumed() && acc.equals(KeyStroke.getKeyStrokeForEvent(e))) {
+      e.consume();
+      dumpDebugInfo();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Performs dumping to {@link System#out standard output} some useful debug information
+   * about currect active objects in the editor:
+   * <ol>
+   * <li>Class and title of top-level window</li>
+   * <li>Class and name of current {@link Viewable}, if such exist</li>
+   * <li>Name of current resource, if viewable is {@link Resource}</li>
+   * <li>Class and name of current field if viewable has opened editor</li>
+   * </ol>
+   */
+  public static void dumpDebugInfo()
+  {
+    final Frame frame = findActiveFrame();
+    if (frame == null) {
+      return;
+    }
+    System.out.println("Current Window  : " + frame.getClass() + ", title: " + frame.getTitle());
+    if (!(frame instanceof ViewableContainer)) {
+      return;
+    }
+    final Viewable v = ((ViewableContainer)frame).getViewable();
+    final String name = v instanceof StructEntry ? ", name: " + ((StructEntry)v).getName() : "";
+    System.out.println("        Viewable: " + (v == null ? null : (v.getClass() + name)));
+    if (v instanceof Resource) {
+      System.out.println("        Resource: " + ((Resource)v).getResourceEntry());
+    }
+    if (v instanceof AbstractStruct) {
+      final StructViewer viewer = ((AbstractStruct)v).getViewer();
+      if (viewer != null) {
+        final StructEntry entry = viewer.getSelectedEntry();
+        final String info = entry == null ? null : (entry.getClass() + ", name: " + entry.getName());
+        System.out.println("        Field   : " + info);
+      }
+    }
+  }
+
+  private static Frame findActiveFrame()
+  {
+    for (Frame frame : Frame.getFrames()) {
+      if (frame.isActive()) {
+        return frame;
+      }
+    }
+    return null;
+  }
+  //</editor-fold>
 
 // -------------------------- INNER CLASSES --------------------------
 
@@ -1316,6 +1382,7 @@ public final class BrowserMenuBar extends JMenuBar
     private final JMenuItem toolConvImageToBam, toolConvImageToBmp, toolConvImageToMos, toolConvImageToTis,
                             toolConvImageToPvrz;
     private final JCheckBoxMenuItem toolConsole, toolClipBoard;
+    private final JMenuItem dumpDebugInfo;
 
     private ToolsMenu()
     {
@@ -1453,6 +1520,11 @@ public final class BrowserMenuBar extends JMenuBar
       toolConsole.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, CTRL_MASK));
       toolConsole.addActionListener(this);
       add(toolConsole);
+      dumpDebugInfo = new JMenuItem("Print debug info to Console");
+      dumpDebugInfo.setToolTipText("Output to console class of current top-level window, resource and selected field in the structure viewer");
+      dumpDebugInfo.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, CTRL_MASK | SHIFT_MASK));
+      dumpDebugInfo.addActionListener(this);
+      add(dumpDebugInfo);
     }
 
 //    private static void cleanKeyfile()
@@ -1528,6 +1600,9 @@ public final class BrowserMenuBar extends JMenuBar
           });
         }
         console.setVisible(toolConsole.isSelected());
+      }
+      else if (event.getSource() == dumpDebugInfo) {
+        dumpDebugInfo();
       }
       else if (event.getSource() == toolCleanKeyfile)
 //        cleanKeyfile();


### PR DESCRIPTION
This feature is very convenient in JMeter -- it is possible to find out quickly in what class there is a code which visual representation you see on the screen. Here it will be very useful too

Shortcut `Ctrl+Shift+D` outputs to the console following information:
* Class and title of top-level window
* Class and name of current `Viewable`, if such exist
* Name of current resource, if viewable is `Resource`
* Class and name of current field if viewable has opened editor

```
Current Window  : class org.infinity.NearInfinity, title: Near Infinity - Planescape: Torment (Planescape: Torment)
        Viewable: class org.infinity.resource.chu.ChuResource, name: GUIALPHA.CHU
        Resource: GUIALPHA.CHU
        Field   : class org.infinity.resource.chu.Window, name: Panel 0
```
![debug info](https://user-images.githubusercontent.com/450131/49700292-81a2df80-fbfe-11e8-9490-a67ba8393540.png)
