### PR TITLE
Implement "Special" node in the resource tree

### DIFF
--- a/src/org/infinity/gui/BrowserMenuBar.java
+++ b/src/org/infinity/gui/BrowserMenuBar.java
@@ -6,7 +6,6 @@ package org.infinity.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -79,7 +78,6 @@ import org.infinity.resource.ResourceFactory;
 import org.infinity.resource.StructureFactory;
 import org.infinity.resource.key.FileResourceEntry;
 import org.infinity.resource.key.ResourceEntry;
-import org.infinity.resource.text.PlainTextResource;
 import org.infinity.search.DialogSearcher;
 import org.infinity.search.SearchFrame;
 import org.infinity.search.SearchResource;
@@ -268,7 +266,6 @@ public final class BrowserMenuBar extends JMenuBar
   {
     gameMenu.gameLoaded(oldGame, oldFile);
     fileMenu.gameLoaded();
-    editMenu.gameLoaded();
     searchMenu.gameLoaded();
     optionsMenu.gameLoaded();
   }
@@ -1104,7 +1101,7 @@ public final class BrowserMenuBar extends JMenuBar
 
   private static final class EditMenu extends JMenu implements ActionListener
   {
-    private final JMenuItem editString, editBIFF, editVarVar, editIni, editWeiDU, editWeiDUBGEE;
+    private final JMenuItem editString, editBIFF;
 
     private EditMenu()
     {
@@ -1114,51 +1111,11 @@ public final class BrowserMenuBar extends JMenuBar
       editString =
           makeMenuItem("String table", KeyEvent.VK_S, Icons.getIcon(Icons.ICON_EDIT_16), KeyEvent.VK_S, this);
       add(editString);
-      editIni = makeMenuItem("baldur.ini", KeyEvent.VK_I, Icons.getIcon(Icons.ICON_EDIT_16), -1, NearInfinity.getInstance());
-      editIni.setActionCommand("GameIni");
-      add(editIni);
-      editWeiDU = makeMenuItem("WeiDU.log", KeyEvent.VK_W, Icons.getIcon(Icons.ICON_EDIT_16), -1, this);
-      add(editWeiDU);
-      editWeiDUBGEE = makeMenuItem("WeiDU-BGEE.log", -1, Icons.getIcon(Icons.ICON_EDIT_16), -1, this);
-      editWeiDUBGEE.setVisible(false);
-      add(editWeiDUBGEE);
-      editVarVar = makeMenuItem("Var.var", KeyEvent.VK_V, Icons.getIcon(Icons.ICON_ROW_INSERT_AFTER_16), -1, this);
-      add(editVarVar);
       // TODO: reactive when fixed
       editBIFF = makeMenuItem("BIFF", KeyEvent.VK_B, Icons.getIcon(Icons.ICON_EDIT_16), KeyEvent.VK_E, this);
       editBIFF.setToolTipText("Temporarily disabled");
       editBIFF.setEnabled(false);
       add(editBIFF);
-    }
-
-    private void gameLoaded()
-    {
-      Path iniFile = Profile.getProperty(Profile.Key.GET_GAME_INI_FILE);
-      if (iniFile != null && Files.isRegularFile(iniFile)) {
-        editIni.setText(iniFile.getFileName().toString());
-        editIni.setEnabled(true);
-        editIni.setToolTipText("Edit " + iniFile.toString());
-      } else {
-        editIni.setText("baldur.ini");
-        editIni.setEnabled(false);
-        editIni.setToolTipText("Ini file not available");
-      }
-
-      Path weiduFile = FileManager.query(Profile.getRootFolders(), "WeiDU.log");
-      editWeiDU.setEnabled(weiduFile != null && Files.isRegularFile(weiduFile));
-      editWeiDUBGEE.setVisible(Profile.getGame() == Profile.Game.EET);
-      if (editWeiDUBGEE.isVisible()) {
-        weiduFile = FileManager.query(Profile.getRootFolders(), "WeiDU-BGEE.log");
-        editWeiDUBGEE.setEnabled(weiduFile != null && Files.isRegularFile(weiduFile));
-      }
-
-      Path varFile = FileManager.query(Profile.getRootFolders(), "VAR.VAR");
-      editVarVar.setEnabled(varFile != null && Files.isRegularFile(varFile));
-      if (editVarVar.isEnabled()) {
-        editVarVar.setToolTipText("");
-      } else {
-        editVarVar.setToolTipText("Only available for Planescape: Torment");
-      }
     }
 
     @Override
@@ -1176,36 +1133,8 @@ public final class BrowserMenuBar extends JMenuBar
           editor.setVisible(true);
         }
       }
-      else if (event.getSource() == editWeiDU) {
-        showTextFile(NearInfinity.getInstance(), "WeiDU.log");
-      }
-      else if (event.getSource() == editWeiDUBGEE) {
-        showTextFile(NearInfinity.getInstance(), "WeiDU-BGEE.log");
-      }
-      else if (event.getSource() == editVarVar) {
-        new ViewFrame(NearInfinity.getInstance(),
-                      ResourceFactory.getResource(
-                              new FileResourceEntry(
-                                  FileManager.queryExisting(Profile.getRootFolders(), "VAR.VAR"))));
-      }
       else if (event.getSource() == editBIFF) {
 //        new BIFFEditor();
-      }
-    }
-
-    /** Opens given file in text editor if file is found in the game's root folder. */
-    private void showTextFile(Component parent, String fileName)
-    {
-      Path logFile = FileManager.query(Profile.getRootFolders(), fileName);
-      try {
-        if (logFile != null && Files.isRegularFile(logFile)) {
-          new ViewFrame(parent, new PlainTextResource(new FileResourceEntry(logFile)));
-        } else {
-          throw new Exception();
-        }
-      } catch (Exception e) {
-        JOptionPane.showMessageDialog(parent, "Cannot open " + fileName + ".",
-                                      "Error", JOptionPane.ERROR_MESSAGE);
       }
     }
   }

--- a/src/org/infinity/resource/key/Keyfile.java
+++ b/src/org/infinity/resource/key/Keyfile.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2018 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.key;
@@ -214,6 +214,8 @@ public class Keyfile
     resourceIcons.put("TXT", ICON_TEXT);
     resourceIcons.put("RES", ICON_TEXT);
     resourceIcons.put("BAF", ICON_SCRIPT);
+    resourceIcons.put("VAR", ICON_STRUCT);// PST VAR.VAR file - from Special category in the resource tree
+    resourceIcons.put("LOG", ICON_TEXT);// WeiDU log files - from Special category in the resource tree
   }
 
   @Override
@@ -440,7 +442,7 @@ public class Keyfile
     }
   }
 
-  // caches all BIFF files referenced in the current KEY file
+  /** Caches all BIFF files referenced in the current KEY file. */
   private void cacheBIFFs()
   {
     SwingUtilities.invokeLater(new Runnable() {
@@ -499,7 +501,7 @@ public class Keyfile
 //  }
 
 
-  // Creates or updates cached biff maps and entry tables
+  /** Creates or updates cached biff maps and entry tables. */
   private void init() throws IOException
   {
     if (getKeyfile() == null) {
@@ -562,7 +564,7 @@ public class Keyfile
     }
   }
 
-  // Returns the list of BIFFEntry objects for the specified key file, optionally removes it
+  /** Returns the list of BIFFEntry objects for the specified key file, optionally removes it. */
   private List<BIFFEntry> getBIFFList(Path keyFile, boolean remove)
   {
     if (keyFile != null) {
@@ -575,7 +577,7 @@ public class Keyfile
     return null;
   }
 
-  // Adds the specified resource entry to the list, overwrites existing entries of same name.
+  /** Adds the specified resource entry to the list, overwrites existing entries of same name. */
   private BIFFResourceEntry addResourceEntry(BIFFResourceEntry entry)
   {
     BIFFResourceEntry retVal = null;

--- a/src/org/infinity/resource/key/ResourceTreeModel.java
+++ b/src/org/infinity/resource/key/ResourceTreeModel.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2018 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.key;
@@ -97,6 +97,15 @@ public final class ResourceTreeModel implements TreeModel
 
 // --------------------- End Interface TreeModel ---------------------
 
+  /**
+   * Recursively adds all files from directory {@code directory} as file resources
+   * under {@code parentFolder}.
+   *
+   * @param parentFolder Navigation tree element under which new fiels will be added
+   * @param directory Directory from which all files will be added (recursively)
+   * @param overwrite If {@code true}, new files will replace existent resources
+   *        otherwise it will be skipped and not added to the tree
+   */
   public void addDirectory(ResourceTreeFolder parentFolder, Path directory, boolean overwrite)
   {
     try (DirectoryStream<Path> dstream = Files.newDirectoryStream(directory)) {
@@ -355,4 +364,3 @@ public final class ResourceTreeModel implements TreeModel
     }
   }
 }
-


### PR DESCRIPTION
@Argent77 , with you help from https://github.com/Argent77/NearInfinity/pull/11#issuecomment-445450019 and my own investigations I create new node in the resource tree and place to it important game files:
![special resources](https://user-images.githubusercontent.com/450131/50426085-40b9f480-08a7-11e9-8531-0027b4e81e46.png)
I also removed them from **Edit** menu -- I think that with new node their presence in the menu no more required.

I am not sure a little whether sufficient conditions for inclusion of these or those files in a tree - it is possible, they can be improved or to refuse absolutely them?

Also this change reduces count of unfunded strings in https://github.com/NearInfinityBrowser/NearInfinity/issues/98, but I think, this still not completely fixes the issue.

List of important files I check in games from GOG:
* Planescape: Torment
* Baldur's Gate: Tales of the Sword Coast
* Baldur's Gate 2: Throne of Baal
* Icewind Dale
* Icewind Dale II
* Icewind Dale: Enhanced Edition