### PR TITLE
Fix #100, add "Raw" tab to DlgResource and fix hole detection algorithm on hole in file end

### DIFF
--- a/src/org/infinity/resource/AbstractStruct.java
+++ b/src/org/infinity/resource/AbstractStruct.java
@@ -1077,7 +1077,7 @@ public abstract class AbstractStruct extends AbstractTableModel implements Struc
     }
     if (endoffset < buffer.limit()) { // Does this break anything?
       list.add(new Unknown(buffer, endoffset, buffer.limit() - endoffset, COMMON_UNUSED_BYTES));
-      System.out.println("Hole: " + name + " off: " + Integer.toHexString(offset) + "h len: " +
+      System.out.println("Hole: " + name + " off: " + Integer.toHexString(endoffset) + "h len: " +
                          (buffer.limit() - endoffset));
       endoffset = buffer.limit();
     }

--- a/src/org/infinity/resource/dlg/DlgResource.java
+++ b/src/org/infinity/resource/dlg/DlgResource.java
@@ -34,6 +34,8 @@ import org.infinity.gui.BrowserMenuBar;
 import org.infinity.gui.ButtonPanel;
 import org.infinity.gui.ButtonPopupMenu;
 import org.infinity.gui.StructViewer;
+import org.infinity.gui.hexview.BasicColorMap;
+import org.infinity.gui.hexview.StructHexViewer;
 import org.infinity.resource.AbstractStruct;
 import org.infinity.resource.AddRemovable;
 import org.infinity.resource.HasAddRemovable;
@@ -110,6 +112,7 @@ public final class DlgResource extends AbstractStruct
   private JMenuItem miExport, miExportWeiDUDialog;
   private Viewer detailViewer;
   private TreeViewer treeViewer;
+  private StructHexViewer hexViewer;
 
   public DlgResource(ResourceEntry entry) throws Exception
   {
@@ -145,7 +148,7 @@ public final class DlgResource extends AbstractStruct
   @Override
   public int getViewerTabCount()
   {
-    return 2;
+    return 3;
   }
 
   @Override
@@ -154,6 +157,7 @@ public final class DlgResource extends AbstractStruct
     switch (index) {
       case 0: return StructViewer.TAB_VIEW;
       case 1: return TAB_TREE;
+      case 2: return StructViewer.TAB_RAW;
     }
     return null;
   }
@@ -170,6 +174,11 @@ public final class DlgResource extends AbstractStruct
         if (treeViewer == null)
           treeViewer = new TreeViewer(this);
         return treeViewer;
+      case 2:
+        if (hexViewer == null) {
+          hexViewer = new StructHexViewer(this, new BasicColorMap(this, true));
+        }
+        return hexViewer;
     }
     return null;
   }

--- a/src/org/infinity/resource/dlg/Viewer.java
+++ b/src/org/infinity/resource/dlg/Viewer.java
@@ -58,8 +58,13 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
   private static final ButtonPanel.Control CtrlPrevState      = ButtonPanel.Control.CUSTOM_2;
   private static final ButtonPanel.Control CtrlNextTrans      = ButtonPanel.Control.CUSTOM_3;
   private static final ButtonPanel.Control CtrlPrevTrans      = ButtonPanel.Control.CUSTOM_4;
+  /** Button that allow move to next state, specified for the response. */
   private static final ButtonPanel.Control CtrlSelect         = ButtonPanel.Control.CUSTOM_5;
-  private static final ButtonPanel.Control CtrlUndo           = ButtonPanel.Control.CUSTOM_6;
+  /**
+   * Button that allow return to previous state, before current was selected by
+   * the {@link #CtrlSelect} button.
+   */
+  private static final ButtonPanel.Control CtrlReturn         = ButtonPanel.Control.CUSTOM_6;
   private static final ButtonPanel.Control CtrlStateField     = ButtonPanel.Control.CUSTOM_7;
   private static final ButtonPanel.Control CtrlResponseField  = ButtonPanel.Control.CUSTOM_8;
 
@@ -114,8 +119,8 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
     JButton bSelect = new JButton("Select", Icons.getIcon(Icons.ICON_REDO_16));
     bSelect.addActionListener(this);
 
-    JButton bUndo = new JButton("Undo", Icons.getIcon(Icons.ICON_UNDO_16));
-    bUndo.addActionListener(this);
+    JButton bReturn = new JButton("Return", Icons.getIcon(Icons.ICON_UNDO_16));
+    bReturn.addActionListener(this);
 
     int width = (int)tfState.getPreferredSize().getWidth();
     int height = (int)bNextState.getPreferredSize().getHeight();
@@ -161,7 +166,7 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
     buttonPanel.addControl(bPrevTrans, CtrlPrevTrans);
     buttonPanel.addControl(bNextTrans, CtrlNextTrans);
     buttonPanel.addControl(bSelect, CtrlSelect);
-    buttonPanel.addControl(bUndo, CtrlUndo);
+    buttonPanel.addControl(bReturn, CtrlReturn);
     buttonPanel.addControl(bpmFind, ButtonPanel.Control.FIND_MENU);
 
     setLayout(new BorderLayout());
@@ -181,13 +186,13 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
       bNextTrans.setEnabled(false);
       bSelect.setEnabled(false);
     }
-    bUndo.setEnabled(false);
+    bReturn.setEnabled(false);
   }
 
   public void setUndoDlg(DlgResource dlg)
   {
     this.undoDlg = dlg;
-    buttonPanel.getControlByType(CtrlUndo).setEnabled(true);
+    buttonPanel.getControlByType(CtrlReturn).setEnabled(true);
   }
 
 // --------------------- Begin Interface ActionListener ---------------------
@@ -196,7 +201,7 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
   public void actionPerformed(ActionEvent event)
   {
     if (!alive) return;
-    if (buttonPanel.getControlByType(CtrlUndo) == event.getSource()) {
+    if (buttonPanel.getControlByType(CtrlReturn) == event.getSource()) {
       JButton bUndo = (JButton)event.getSource();
       if(lastStates.empty() && (undoDlg != null)) {
         showExternState(undoDlg, -1, true);
@@ -251,7 +256,7 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
         if (dlg.getResourceEntry().toString().equalsIgnoreCase(next_dlg.toString())) {
           lastStates.push(currentstate);
           lastTransitions.push(currenttransition);
-          buttonPanel.getControlByType(CtrlUndo).setEnabled(true);
+          buttonPanel.getControlByType(CtrlReturn).setEnabled(true);
           newstate = currenttransition.getNextDialogState();
         } else {
           DlgResource newdlg =

--- a/src/org/infinity/resource/dlg/Viewer.java
+++ b/src/org/infinity/resource/dlg/Viewer.java
@@ -92,9 +92,9 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
   //</editor-fold>
 
   /** State that editor shows right now. */
-  private State currentstate;
+  private State currentState;
   /** Transition that editor shows right now. */
-  private Transition currenttransition;
+  private Transition currentTrans;
 
   //<editor-fold defaultstate="collapsed" desc="Select/Return">
   /**
@@ -213,7 +213,7 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
 
     if (!stateList.isEmpty()) {
       showState(0);
-      showTransition(currentstate.getFirstTrans());
+      showTransition(currentState.getFirstTrans());
     } else {
       bPrevState.setEnabled(false);
       bNextState.setEnabled(false);
@@ -247,15 +247,15 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
       if (lastStates.empty() && (undoDlg == null)) {
         bUndo.setEnabled(false);
       }
-      if (oldstate != currentstate) {
+      if (oldstate != currentState) {
         showState(oldstate.getNumber());
       }
-      if (oldtrans != currenttransition) {
+      if (oldtrans != currentTrans) {
         showTransition(oldtrans.getNumber());
       }
     } else {
-      int newstate = currentstate.getNumber();
-      int newtrans = currenttransition.getNumber();
+      int newstate = currentState.getNumber();
+      int newtrans = currentTrans.getNumber();
       if (buttonPanel.getControlByType(CtrlNextState) == event.getSource()) {
         newstate++;
       } else if (buttonPanel.getControlByType(CtrlPrevState) == event.getSource()) {
@@ -270,42 +270,40 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
           if (number >= 0 && number <= stateList.size()) {
             newstate = number;
           } else {
-            tfState.setText(String.valueOf(currentstate.getNumber()));
+            tfState.setText(String.valueOf(currentState.getNumber()));
           }
         } catch (Exception e) {
-          tfState.setText(String.valueOf(currentstate.getNumber()));
+          tfState.setText(String.valueOf(currentState.getNumber()));
         }
       } else if (event.getSource() == tfResponse) {
         try {
           int number = Integer.parseInt(tfResponse.getText());
-          if (number >= 0 && number <= currentstate.getTransCount()) {
-            newtrans = currentstate.getFirstTrans() + number;
+          if (number >= 0 && number <= currentState.getTransCount()) {
+            newtrans = currentState.getFirstTrans() + number;
           } else {
-            tfResponse.setText(String.valueOf(currenttransition.getNumber() - currentstate.getFirstTrans()));
+            tfResponse.setText(String.valueOf(currentTrans.getNumber() - currentState.getFirstTrans()));
           }
         } catch (Exception e) {
-          tfResponse.setText(String.valueOf(currenttransition.getNumber() - currentstate.getFirstTrans()));
+          tfResponse.setText(String.valueOf(currentTrans.getNumber() - currentState.getFirstTrans()));
         }
       } else if (buttonPanel.getControlByType(CtrlSelect) == event.getSource()) {
-        final String nextDlgName = currenttransition.getNextDialog().getResourceName();
+        final String nextDlgName = currentTrans.getNextDialog().getResourceName();
         if (dlg.getResourceEntry().getResourceName().equalsIgnoreCase(nextDlgName)) {
-          lastStates.push(currentstate);
-          lastTransitions.push(currenttransition);
+          lastStates.push(currentState);
+          lastTransitions.push(currentTrans);
           buttonPanel.getControlByType(CtrlReturn).setEnabled(true);
-          newstate = currenttransition.getNextDialogState();
+          newstate = currentTrans.getNextDialogState();
         } else {
           DlgResource newdlg =
               (DlgResource)ResourceFactory.getResource(ResourceFactory.getResourceEntry(nextDlgName));
-          showExternState(newdlg, currenttransition.getNextDialogState(), false);
+          showExternState(newdlg, currentTrans.getNextDialogState(), false);
         }
       }
-      if (alive) {
-        if (newstate != currentstate.getNumber()) {
-          showState(newstate);
-          showTransition(stateList.get(newstate).getFirstTrans());
-        } else if (newtrans != currenttransition.getNumber()) {
-          showTransition(newtrans);
-        }
+      if (newstate != currentState.getNumber()) {
+        showState(newstate);
+        showTransition(stateList.get(newstate).getFirstTrans());
+      } else if (newtrans != currentTrans.getNumber()) {
+        showTransition(newtrans);
       }
     }
   }
@@ -340,8 +338,8 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
   public void tableChanged(TableModelEvent e)
   {
     updateViewerLists();
-    showState(currentstate.getNumber());
-    showTransition(currenttransition.getNumber());
+    showState(currentState.getNumber());
+    showTransition(currentTrans.getNumber());
   }
 
 // --------------------- End Interface TableModelListener ---------------------
@@ -466,19 +464,19 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
    */
   private void showState(int nr)
   {
-    if (currentstate != null) {
-      currentstate.removeTableModelListener(this);
+    if (currentState != null) {
+      currentState.removeTableModelListener(this);
     }
-    currentstate = stateList.get(nr);
-    currentstate.addTableModelListener(this);
+    currentState = stateList.get(nr);
+    currentState.addTableModelListener(this);
 
     final int cnt = stateList.size() - 1;
     bostate.setTitle("State " + nr + '/' + cnt);
-    stateTextPanel.display(currentstate, nr);
+    stateTextPanel.display(currentState, nr);
     tfState.setText(String.valueOf(nr));
     outerpanel.repaint();
 
-    final int trigger = currentstate.getTriggerIndex();
+    final int trigger = currentState.getTriggerIndex();
     if (trigger != 0xffffffff) {
       stateTriggerPanel.display(staTriList.get(trigger), trigger);
     } else {
@@ -495,29 +493,29 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
    */
   private void showTransition(int nr)
   {
-    if (currenttransition != null) {
-      currenttransition.removeTableModelListener(this);
+    if (currentTrans != null) {
+      currentTrans.removeTableModelListener(this);
     }
-    currenttransition = transList.get(nr);
-    currenttransition.addTableModelListener(this);
+    currentTrans = transList.get(nr);
+    currentTrans.addTableModelListener(this);
 
     // Relative number of transition in the state
-    final int num = nr - currentstate.getFirstTrans();
-    final int cnt = currentstate.getTransCount() - 1;
+    final int num = nr - currentState.getFirstTrans();
+    final int cnt = currentState.getTransCount() - 1;
     botrans.setTitle("Response " + num + '/' + cnt);
     tfResponse.setText(String.valueOf(num));
     outerpanel.repaint();
-    transTextPanel.display(currenttransition, nr);
+    transTextPanel.display(currentTrans, nr);
 
-    final Flag flags = currenttransition.getFlag();
+    final Flag flags = currentTrans.getFlag();
     if (flags.isFlagSet(1)) {// Bit 1: has trigger
-      final int trigger = currenttransition.getTriggerIndex();
+      final int trigger = currentTrans.getTriggerIndex();
       transTriggerPanel.display(transTriList.get(trigger), trigger);
     } else {
       transTriggerPanel.clearDisplay();
     }
     if (flags.isFlagSet(2)) {// Bit 2: has action
-      final int action = currenttransition.getActionIndex();
+      final int action = currentTrans.getActionIndex();
       transActionPanel.display(actionList.get(action), action);
     } else {
       transActionPanel.clearDisplay();
@@ -570,7 +568,7 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
     } else {
       newdlg_viewer.setUndoDlg(this.dlg);
       newdlg_viewer.showState(state);
-      newdlg_viewer.showTransition(newdlg_viewer.currentstate.getFirstTrans());
+      newdlg_viewer.showTransition(newdlg_viewer.currentState.getFirstTrans());
     }
 
     // make sure the viewer tab is selected

--- a/src/org/infinity/resource/dlg/Viewer.java
+++ b/src/org/infinity/resource/dlg/Viewer.java
@@ -68,27 +68,62 @@ final class Viewer extends JPanel implements ActionListener, ItemListener, Table
   private static final ButtonPanel.Control CtrlStateField     = ButtonPanel.Control.CUSTOM_7;
   private static final ButtonPanel.Control CtrlResponseField  = ButtonPanel.Control.CUSTOM_8;
 
+  //<editor-fold defaultstate="collapsed" desc="Dialog content">
+  private final DlgResource dlg;
+  /** List of all states, found in {@link #dlg}. */
+  private final List<State> stateList = new ArrayList<>();
+  /** List of all transitions, found in {@link #dlg}. */
+  private final List<Transition> transList = new ArrayList<>();
+  /**
+   * List of all state triggers, found in {@link #dlg}. Trigger determines conditions
+   * when state will be visible in the dialogue.
+   */
+  private final List<StateTrigger> staTriList = new ArrayList<>();
+  /**
+   * List of all transition triggers, found in {@link #dlg}. Trigger determines
+   * conditions when transition will be available for selection in the dialogue.
+   */
+  private final List<ResponseTrigger> transTriList = new ArrayList<>();
+  /**
+   * List of all state actions, found in {@link #dlg}. Action determines what
+   * will be do when game process entering to related state.
+   */
+  private final List<Action> actionList = new ArrayList<>();
+  //</editor-fold>
+
+  /** State that editor shows right now. */
+  private State currentstate;
+  /** Transition that editor shows right now. */
+  private Transition currenttransition;
+
+  //<editor-fold defaultstate="collapsed" desc="Select/Return">
+  /**
+   * Stack of states, that were selected by the {@link #CtrlSelect} button. The
+   * {@link #CtrlReturn} button allows return to one of this states together with
+   * transition from {@link #lastTransitions}
+   */
+  private final Stack<State> lastStates = new Stack<>();
+  /**
+   * Stack of transitions, that were current at moment when next state selected
+   * by the {@link #CtrlSelect} button. The {@link #CtrlReturn} button allows return
+   * to one of this transitions together with state from {@link #lastStates}
+   */
+  private final Stack<Transition> lastTransitions = new Stack<>();
+  private DlgResource undoDlg;
+  private boolean alive = true;
+  //</editor-fold>
+
+  //<editor-fold defaultstate="collapsed" desc="GUI">
   private final ButtonPanel buttonPanel = new ButtonPanel();
   private final DlgPanel stateTextPanel, stateTriggerPanel, transTextPanel, transTriggerPanel, transActionPanel;
-  private final DlgResource dlg;
   private final JMenuItem ifindall = new JMenuItem("in all DLG files");
   private final JMenuItem ifindthis = new JMenuItem("in this file only");
   private final JPanel outerpanel;
   private final JTextField tfState = new JTextField(4);
   private final JTextField tfResponse = new JTextField(4);
-  private final List<Action> actionList = new ArrayList<Action>();
-  private final List<ResponseTrigger> transTriList = new ArrayList<ResponseTrigger>();
-  private final List<State> stateList = new ArrayList<State>();
-  private final List<StateTrigger> staTriList = new ArrayList<StateTrigger>();
-  private final List<Transition> transList = new ArrayList<Transition>();
-  private final Stack<State> lastStates = new Stack<State>();
-  private final Stack<Transition> lastTransitions = new Stack<Transition>();
   private final TitledBorder bostate = new TitledBorder("State");
   private final TitledBorder botrans = new TitledBorder("Response");
-  private State currentstate;
-  private Transition currenttransition;
-  private boolean alive = true;
-  private DlgResource undoDlg;
+  //</editor-fold>
 
   Viewer(DlgResource dlg)
   {


### PR DESCRIPTION
Also now dialog editor able to show dialogs with corrupted structure (absence of states/responses/triggers/actions). Such elements is shown with red titles and additional string `"(broken ...)"`.

Also I add **Raw** tab for dialog resources and fix small misprint in hole detection algorithm.

![broken dialogs](https://user-images.githubusercontent.com/450131/50524688-0182e200-0af9-11e9-8a54-002d3256a4b3.png)
![raw tab](https://user-images.githubusercontent.com/450131/50524762-5cb4d480-0af9-11e9-8bb2-b00d69368409.png)
