### PR TITLE
Add ability to select any state/response in the tree

### DIFF
--- a/src/org/infinity/gui/StructViewer.java
+++ b/src/org/infinity/gui/StructViewer.java
@@ -649,7 +649,7 @@ public final class StructViewer extends JPanel implements ListSelectionListener,
           new ReferenceSearcher(struct.getResourceEntry(), getTopLevelAncestor());
         } else if (item == miFindStateReferences) {
           State state = (State)table.getValueAt(table.getSelectedRow(), 1);
-          new DialogStateReferenceSearcher(struct.getResourceEntry(), state.getNumber(), getTopLevelAncestor());
+          new DialogStateReferenceSearcher(struct.getResourceEntry(), state, getTopLevelAncestor());
         } else if (item == miFindRefToItem) {
           new DialogItemRefSearcher((DlgResource) struct, table.getValueAt(table.getSelectedRow(), 1),
                                     getTopLevelAncestor());

--- a/src/org/infinity/resource/dlg/DlgItem.java
+++ b/src/org/infinity/resource/dlg/DlgItem.java
@@ -19,8 +19,8 @@ import org.infinity.gui.BrowserMenuBar;
 import org.infinity.icon.Icons;
 import org.infinity.resource.StructEntry;
 
-/** Meta class for identifying root node. */
-final class RootItem extends StateOwnerItem implements Iterable<StateItem>
+/** Meta class for identifying dialogue node. */
+final class DlgItem extends StateOwnerItem implements Iterable<StateItem>
 {
   private static final ImageIcon ICON = Icons.getIcon(Icons.ICON_ROW_INSERT_AFTER_16);
 
@@ -36,7 +36,7 @@ final class RootItem extends StateOwnerItem implements Iterable<StateItem>
   private final int numActions;
   private final String flags;
 
-  public RootItem(DlgResource dlg)
+  public DlgItem(DlgResource dlg)
   {
     this.dlg = dlg;
     numStates           = getAttribute(DlgResource.DLG_NUM_STATES);

--- a/src/org/infinity/resource/dlg/DlgItem.java
+++ b/src/org/infinity/resource/dlg/DlgItem.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -24,6 +24,7 @@ final class DlgItem extends StateOwnerItem implements Iterable<StateItem>
 {
   private static final ImageIcon ICON = Icons.getIcon(Icons.ICON_ROW_INSERT_AFTER_16);
 
+  private final DlgTreeModel parent;
   /** Dialog which represents this tree. */
   private final DlgResource dlg;
   /** States from which dialog can start. */
@@ -36,8 +37,9 @@ final class DlgItem extends StateOwnerItem implements Iterable<StateItem>
   private final int numActions;
   private final String flags;
 
-  public DlgItem(DlgResource dlg)
+  public DlgItem(DlgTreeModel parent, DlgResource dlg)
   {
+    this.parent = parent;
     this.dlg = dlg;
     numStates           = getAttribute(DlgResource.DLG_NUM_STATES);
     numTransitions      = getAttribute(DlgResource.DLG_NUM_RESPONSES);
@@ -89,7 +91,7 @@ final class DlgItem extends StateOwnerItem implements Iterable<StateItem>
   public int getChildCount() { return states.size(); }
 
   @Override
-  public ItemBase getParent() { return null; }
+  public TreeNode getParent() { return parent; }
 
   @Override
   public int getIndex(TreeNode node) { return states.indexOf(node); }

--- a/src/org/infinity/resource/dlg/DlgTreeModel.java
+++ b/src/org/infinity/resource/dlg/DlgTreeModel.java
@@ -33,13 +33,13 @@ final class DlgTreeModel implements TreeModel, TableModelListener
   /** Maps dialog entries to tree items that represents it. Used for update tree when entry changes. */
   private final HashMap<TreeItemEntry, List<ItemBase>> allItems = new HashMap<>();
 
-  private final RootItem root;
+  private final DlgItem root;
 
   public DlgTreeModel(DlgResource dlg)
   {
     linkedDialogs.put(key(dlg.getName()), dlg);
 
-    root = new RootItem(dlg);
+    root = new DlgItem(dlg);
     for (StateItem state : root) {
       initState(state);
       putItem(state, null);
@@ -49,7 +49,7 @@ final class DlgTreeModel implements TreeModel, TableModelListener
 
   //<editor-fold defaultstate="collapsed" desc="TreeModel">
   @Override
-  public RootItem getRoot() { return root; }
+  public DlgItem getRoot() { return root; }
 
   @Override
   public ItemBase getChild(Object parent, int index)

--- a/src/org/infinity/resource/dlg/DlgTreeModel.java
+++ b/src/org/infinity/resource/dlg/DlgTreeModel.java
@@ -326,6 +326,7 @@ final class DlgTreeModel implements TreeModel, TableModelListener
       state = queue.poll();
       if (state == null) break;
 
+      initState(state);
       for (TransitionItem trans : state) {
         if (trans.getMain() != null) continue;
         initTransition(trans);

--- a/src/org/infinity/resource/dlg/ItemBase.java
+++ b/src/org/infinity/resource/dlg/ItemBase.java
@@ -125,3 +125,15 @@ abstract class StateOwnerItem extends ItemBase
   public abstract Enumeration<? extends StateItem> children();
   //</editor-fold>
 }
+
+/** Auxiliary class, being the parent for transitions, for a type safety. */
+abstract class TransitionOwnerItem extends ItemBase implements Iterable<TransitionItem>
+{
+  //<editor-fold defaultstate="collapsed" desc="TreeNode">
+  @Override
+  public abstract TransitionItem getChildAt(int childIndex);
+
+  @Override
+  public abstract Enumeration<? extends TransitionItem> children();
+  //</editor-fold>
+}

--- a/src/org/infinity/resource/dlg/ItemBase.java
+++ b/src/org/infinity/resource/dlg/ItemBase.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -45,11 +45,14 @@ abstract class ItemBase implements TreeNode
    */
   public TreePath getPath()
   {
-    final ItemBase parent = getParent();
+    final TreeNode parent = getParent();
+    if (parent instanceof ItemBase) {
+      return ((ItemBase)parent).getPath().pathByAddingChild(this);
+    }
     if (parent == null) {
       return new TreePath(this);
     }
-    return parent.getPath().pathByAddingChild(this);
+    return new TreePath(parent).pathByAddingChild(this);
   }
 
   /** Returns the entry of the dialog which this node represents. */
@@ -76,9 +79,6 @@ abstract class ItemBase implements TreeNode
   //<editor-fold defaultstate="collapsed" desc="TreeNode">
   @Override
   public abstract ItemBase getChildAt(int childIndex);
-
-  @Override
-  public abstract ItemBase getParent();
 
   @Override
   public abstract Enumeration<? extends ItemBase> children();

--- a/src/org/infinity/resource/dlg/OrphanStates.java
+++ b/src/org/infinity/resource/dlg/OrphanStates.java
@@ -1,0 +1,75 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.dlg;
+
+import java.util.ArrayList;
+import static java.util.Collections.enumeration;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import javax.swing.Icon;
+import javax.swing.tree.TreeNode;
+
+/**
+ * Represents node in the dialog tree that contains states, that not accessible
+ * from any other dialog
+ *
+ * @author Mingun
+ */
+final class OrphanStates extends StateOwnerItem implements Iterable<StateItem>
+{
+  private final DlgTreeModel parent;
+  final List<StateItem> states = new ArrayList<>();
+
+  public OrphanStates(DlgTreeModel parent) { this.parent = parent; }
+
+  @Override
+  public String toString() { return "Orphan states"; }
+
+  //<editor-fold defaultstate="collapsed" desc="TreeNode">
+  @Override
+  public StateItem getChildAt(int childIndex) { return states.get(childIndex); }
+
+  @Override
+  public int getChildCount() { return states.size(); }
+
+  @Override
+  public TreeNode getParent() { return parent; }
+
+  @Override
+  public int getIndex(TreeNode node) { return states.indexOf(node); }
+
+  @Override
+  public boolean getAllowsChildren() { return true; }
+
+  @Override
+  public boolean isLeaf() { return states.isEmpty(); }
+
+  @Override
+  public Enumeration<? extends StateItem> children() { return enumeration(states); }
+  //</editor-fold>
+
+  //<editor-fold defaultstate="collapsed" desc="Iterable">
+  @Override
+  public Iterator<StateItem> iterator() { return states.iterator(); }
+  //</editor-fold>
+
+  //<editor-fold defaultstate="collapsed" desc="ItemBase">
+  @Override
+  public TreeItemEntry getEntry() { return null; }
+
+  @Override
+  public ItemBase getMain() { return null; }
+
+  @Override
+  public DlgResource getDialog() { return parent.getDialog(); }
+
+  @Override
+  public Icon getIcon() { return null; }
+
+  @Override
+  public boolean removeChild(ItemBase child) { return states.remove(child); }
+  //</editor-fold>
+}

--- a/src/org/infinity/resource/dlg/OrphanTransitions.java
+++ b/src/org/infinity/resource/dlg/OrphanTransitions.java
@@ -1,0 +1,75 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.resource.dlg;
+
+import java.util.ArrayList;
+import static java.util.Collections.enumeration;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import javax.swing.Icon;
+import javax.swing.tree.TreeNode;
+
+/**
+ * Represents node in the dialog tree that contains transitions, that not accessible
+ * from any other dialog
+ *
+ * @author Mingun
+ */
+final class OrphanTransitions extends TransitionOwnerItem
+{
+  private final DlgTreeModel parent;
+  final List<TransitionItem> trans = new ArrayList<>();
+
+  public OrphanTransitions(DlgTreeModel parent) { this.parent = parent; }
+
+  @Override
+  public String toString() { return "Orphan responses"; }
+
+  //<editor-fold defaultstate="collapsed" desc="TreeNode">
+  @Override
+  public TransitionItem getChildAt(int childIndex) { return trans.get(childIndex); }
+
+  @Override
+  public int getChildCount() { return trans.size(); }
+
+  @Override
+  public TreeNode getParent() { return parent; }
+
+  @Override
+  public int getIndex(TreeNode node) { return trans.indexOf(node); }
+
+  @Override
+  public boolean getAllowsChildren() { return true; }
+
+  @Override
+  public boolean isLeaf() { return trans.isEmpty(); }
+
+  @Override
+  public Enumeration<? extends TransitionItem> children() { return enumeration(trans); }
+  //</editor-fold>
+
+  //<editor-fold defaultstate="collapsed" desc="Iterable">
+  @Override
+  public Iterator<TransitionItem> iterator() { return trans.iterator(); }
+  //</editor-fold>
+
+  //<editor-fold defaultstate="collapsed" desc="ItemBase">
+  @Override
+  public TreeItemEntry getEntry() { return null; }
+
+  @Override
+  public ItemBase getMain() { return null; }
+
+  @Override
+  public DlgResource getDialog() { return parent.getDialog(); }
+
+  @Override
+  public Icon getIcon() { return null; }
+
+  @Override
+  public boolean removeChild(ItemBase child) { return trans.remove(child); }
+  //</editor-fold>
+}

--- a/src/org/infinity/resource/dlg/State.java
+++ b/src/org/infinity/resource/dlg/State.java
@@ -42,6 +42,9 @@ public final class State extends AbstractStruct implements AddRemovable, TreeIte
 
   //<editor-fold defaultstate="collapsed" desc="TreeItemEntry">
   @Override
+  public DlgResource getParent() { return (DlgResource)super.getParent(); }
+
+  @Override
   public boolean hasAssociatedText() { return true; }
 
   @Override

--- a/src/org/infinity/resource/dlg/StateItem.java
+++ b/src/org/infinity/resource/dlg/StateItem.java
@@ -19,7 +19,7 @@ import org.infinity.gui.BrowserMenuBar;
 import org.infinity.icon.Icons;
 
 /** Encapsulates a dialog state entry. */
-final class StateItem extends ItemBase implements Iterable<TransitionItem>
+final class StateItem extends TransitionOwnerItem
 {
   private static final ImageIcon ICON = Icons.getIcon(Icons.ICON_STOP_16);
 

--- a/src/org/infinity/resource/dlg/StateItem.java
+++ b/src/org/infinity/resource/dlg/StateItem.java
@@ -49,7 +49,7 @@ final class StateItem extends ItemBase implements Iterable<TransitionItem>
   public StateItem getMain() { return main; }
 
   @Override
-  public DlgResource getDialog() { return (DlgResource)state.getParent(); }
+  public DlgResource getDialog() { return state.getParent(); }
 
   @Override
   public Icon getIcon() { return ICON; }

--- a/src/org/infinity/resource/dlg/Transition.java
+++ b/src/org/infinity/resource/dlg/Transition.java
@@ -47,6 +47,9 @@ public final class Transition extends AbstractStruct implements AddRemovable, Tr
   }
 
   //<editor-fold defaultstate="collapsed" desc="TreeItemEntry">
+  @Override
+  public DlgResource getParent() { return (DlgResource)super.getParent(); }
+
   // Flag 0: Transition contains text
   @Override
   public boolean hasAssociatedText() { return getFlag().isFlagSet(0); }
@@ -56,7 +59,7 @@ public final class Transition extends AbstractStruct implements AddRemovable, Tr
   {
     return (StringRef)getAttribute(DLG_TRANS_TEXT, false);
   }
-//</editor-fold>
+  //</editor-fold>
 
   public int getActionIndex()
   {

--- a/src/org/infinity/resource/dlg/TransitionItem.java
+++ b/src/org/infinity/resource/dlg/TransitionItem.java
@@ -25,7 +25,7 @@ final class TransitionItem extends StateOwnerItem
   private final Transition trans;
 
   /** Parent tree item from which this transition is available. */
-  private final StateItem parent;
+  private final TransitionOwnerItem parent;
   /**
    * Item to which need go to in break cycles tree view mode. This item contains
    * referense to the same transition as this one (i.e. {@code this.trans == main.trans})
@@ -34,7 +34,7 @@ final class TransitionItem extends StateOwnerItem
   /** Tree item to which go this transition or {@code null}, if this transition terminates dialog. */
   StateItem nextState;
 
-  public TransitionItem(Transition trans, StateItem parent, TransitionItem main)
+  public TransitionItem(Transition trans, TransitionOwnerItem parent, TransitionItem main)
   {
     this.trans  = Objects.requireNonNull(trans,  "Transition dialog entry must be not null");
     this.parent = Objects.requireNonNull(parent, "Parent tree of transition item must be not null");
@@ -71,7 +71,7 @@ final class TransitionItem extends StateOwnerItem
   public int getChildCount() { return isMain() && nextState != null ? 1 : 0; }
 
   @Override
-  public StateItem getParent() { return parent; }
+  public TransitionOwnerItem getParent() { return parent; }
 
   @Override
   public int getIndex(TreeNode node) { return isMain() && node != null && node == nextState ? 0 : -1; }

--- a/src/org/infinity/resource/dlg/TransitionItem.java
+++ b/src/org/infinity/resource/dlg/TransitionItem.java
@@ -48,7 +48,7 @@ final class TransitionItem extends StateOwnerItem
   public TransitionItem getMain() { return main; }
 
   @Override
-  public DlgResource getDialog() { return (DlgResource)trans.getParent(); }
+  public DlgResource getDialog() { return trans.getParent(); }
 
   @Override
   public Icon getIcon() { return ICON; }

--- a/src/org/infinity/resource/dlg/TreeItemEntry.java
+++ b/src/org/infinity/resource/dlg/TreeItemEntry.java
@@ -14,6 +14,9 @@ import org.infinity.resource.StructEntry;
  */
 public interface TreeItemEntry extends StructEntry
 {
+  @Override
+  DlgResource getParent();
+
   /**
    * Determines has this entry text or not, even if it contains some string reference.
    *

--- a/src/org/infinity/resource/dlg/TreeViewer.java
+++ b/src/org/infinity/resource/dlg/TreeViewer.java
@@ -393,10 +393,6 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
     dlgTree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
     dlgTree.setRootVisible(true);
     dlgTree.setEditable(false);
-    DefaultTreeCellRenderer tcr = (DefaultTreeCellRenderer)dlgTree.getCellRenderer();
-    tcr.setLeafIcon(null);
-    tcr.setOpenIcon(null);
-    tcr.setClosedIcon(null);
 
     // drawing custom icons for each node type
     dlgTree.setCellRenderer(new DefaultTreeCellRenderer() {

--- a/src/org/infinity/resource/dlg/TreeViewer.java
+++ b/src/org/infinity/resource/dlg/TreeViewer.java
@@ -139,7 +139,7 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
         if (viewer != null) {
           // selecting table entry
           final Viewer tab = (Viewer)curDlg.getViewerTab(0);
-          if (item instanceof RootItem) {
+          if (item instanceof DlgItem) {
             viewer.selectEntry(0);
           } else {
             final TreeItemEntry s = item.getEntry();

--- a/src/org/infinity/resource/dlg/TreeViewer.java
+++ b/src/org/infinity/resource/dlg/TreeViewer.java
@@ -242,7 +242,10 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
    */
   public boolean select(TreeItemEntry entry)
   {
-    final ItemBase item = dlgModel.map(entry);
+    ItemBase item = dlgModel.map(entry);
+    if (item == null) {
+      item = dlgModel.addToRoot(entry);
+    }
     if (item != null) {
       final TreePath path = item.getPath();
       dlgTree.addSelectionPath(path);

--- a/src/org/infinity/resource/dlg/TreeViewer.java
+++ b/src/org/infinity/resource/dlg/TreeViewer.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -108,8 +108,10 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
     super(new BorderLayout());
     this.dlg = dlg;
     dlgModel = new DlgTreeModel(dlg);
-    dlgTree = new JTree(dlgModel);
+    dlgTree = new JTree((TreeModel)dlgModel);
     dlgTree.addTreeSelectionListener(this);
+    // Expand first dialog first level
+    dlgTree.expandPath(dlgModel.getMainDlgPath());
     dlgInfo = new ItemInfo();
     initControls();
   }
@@ -410,7 +412,11 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
                                                     boolean expanded, boolean leaf, int row,
                                                     boolean focused)
       {
-        Component c = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, focused);
+        final Component c = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, focused);
+        // Tree reuse component, so we need to clear background
+        setBackgroundNonSelectionColor(null);
+        if (!(value instanceof ItemBase)) return c;
+
         final ItemBase data = (ItemBase)value;
 
         final BrowserMenuBar options = BrowserMenuBar.getInstance();
@@ -478,7 +484,10 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
           final TreePath path = dlgTree.getPathForLocation(e.getX(), e.getY());
           if (path == null) { return; }
 
-          final ItemBase item = (ItemBase)path.getLastPathComponent();
+          final Object last = path.getLastPathComponent();
+          if (!(last instanceof ItemBase)) { return; }
+
+          final ItemBase item = (ItemBase)last;
           if (!item.getAllowsChildren() && item.getMain() != null) {
             final TreePath target = item.getMain().getPath();
             dlgTree.setSelectionPath(target);
@@ -498,9 +507,9 @@ final class TreeViewer extends JPanel implements ActionListener, TreeSelectionLi
         if (e.getSource() == dlgTree && e.isPopupTrigger()) {
           final TreePath path = dlgTree.getClosestPathForLocation(e.getX(), e.getY());
           dlgTree.setSelectionPath(path);
-          final boolean isNonRoot = path != null && path.getPathCount() > 1;
+          final boolean isNonRoot = path != null && path.getLastPathComponent() instanceof ItemBase;
 
-          miEditEntry.setEnabled(path != null);
+          miEditEntry.setEnabled(isNonRoot);
           miExpand.setEnabled(isNonRoot && !isNodeExpanded(path));
           miCollapse.setEnabled(isNonRoot && !isNodeCollapsed(path));
 

--- a/src/org/infinity/resource/dlg/TreeWorker.java
+++ b/src/org/infinity/resource/dlg/TreeWorker.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2018 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.resource.dlg;
@@ -74,10 +74,11 @@ class TreeWorker extends SwingWorker<Void, Void>
   {
     if (progress.isCanceled()) return;
 
-    final ItemBase node = (ItemBase)path.getLastPathComponent();
+    final Object node = path.getLastPathComponent();
+    final boolean isRef = node instanceof ItemBase && ((ItemBase)node).getMain() != null;
 
     // Do not try expand recursive structures
-    if (node.getMain() != null) return;
+    if (isRef) return;
 
     advanceProgress();
     if (!dlgTree.isExpanded(path)) {
@@ -100,18 +101,18 @@ class TreeWorker extends SwingWorker<Void, Void>
   /** Collapses all children and their children of the given path. */
   private void collapseNode(final TreePath path)
   {
-    System.err.println("collapse: "+path);
     if (progress.isCanceled()) return;
-    advanceProgress();
 
-    final ItemBase node = (ItemBase)path.getLastPathComponent();
+    final Object node = path.getLastPathComponent();
+    final boolean isRef = node instanceof ItemBase && ((ItemBase)node).getMain() != null;
 
     // Do not try collapse recursive structures
     // This will collapse all main nodes (even under already collapsed nodes)
     // and will not collapse non-main nodes under collapsed nodes (but still
     // collapse non-main nodes under expanded nodes)
-    if (node.getMain() != null && dlgTree.isCollapsed(path)) return;
+    if (isRef && dlgTree.isCollapsed(path)) return;
 
+    advanceProgress();
     // Use access via model because it properly initializes items
     final TreeModel model = dlgTree.getModel();
     for (int i = 0, count = model.getChildCount(node); i < count; ++i) {

--- a/src/org/infinity/search/DialogStateReferenceSearcher.java
+++ b/src/org/infinity/search/DialogStateReferenceSearcher.java
@@ -7,9 +7,8 @@ package org.infinity.search;
 import java.awt.Component;
 
 import org.infinity.resource.Resource;
-import org.infinity.resource.StructEntry;
 import org.infinity.resource.dlg.DlgResource;
-import org.infinity.resource.dlg.Transition;
+import org.infinity.resource.dlg.State;
 import org.infinity.resource.key.ResourceEntry;
 
 /**
@@ -19,7 +18,7 @@ import org.infinity.resource.key.ResourceEntry;
 public final class DialogStateReferenceSearcher extends AbstractReferenceSearcher
 {
   /** Searched state. Together with {@link #targetEntry} makes subject to search. */
-  private final int targetStateNr;
+  private final State targetState;
 
   /**
    * Creates finder that searches dialogue state (NPC reply) in the other dialogues.
@@ -29,10 +28,10 @@ public final class DialogStateReferenceSearcher extends AbstractReferenceSearche
    * @param searchedState Searched state number -- the NPC reply
    * @param parent GUI component that will be parent for results window
    */
-  public DialogStateReferenceSearcher(ResourceEntry searchedDialog, int searchedState, Component parent)
+  public DialogStateReferenceSearcher(ResourceEntry searchedDialog, State searchedState, Component parent)
   {
     super(searchedDialog, new String[]{"DLG"}, parent);
-    targetStateNr = searchedState;
+    targetState = searchedState;
   }
 
   @Override
@@ -42,15 +41,6 @@ public final class DialogStateReferenceSearcher extends AbstractReferenceSearche
     if (!(resource instanceof DlgResource)) return;
 
     final DlgResource dlg = (DlgResource)resource;
-    final String name = targetEntry.getResourceName();
-    for (int i = 0; i < dlg.getFieldCount(); i++) {
-      StructEntry structEntry = dlg.getField(i);
-      if (structEntry instanceof Transition) {
-        Transition transition = (Transition)structEntry;
-        if (transition.getNextDialog().getResourceName().equalsIgnoreCase(name) &&
-            transition.getNextDialogState() == targetStateNr)
-          addHit(entry, null, transition);
-      }
-    }
+    dlg.findUsages(targetState, t -> addHit(entry, null, t));
   }
 }


### PR DESCRIPTION
Now the user will never see messages "<state/response> is unattainable from the dialogue root. It may be referenced by an external dialogue". Instead for those states/transitions to which it is possible to get from any existing dialog this dialog is inserted into a tree and the element is shown in the appropriate place of a tree:
![Inaccessible states in the tree](https://user-images.githubusercontent.com/450131/59556005-30bcdb00-8fd5-11e9-942a-7f735a06c57b.png)

Such situation can be tested on dialog **DMorte1.dlg** in PS:T. States 31-34 and responses 41-44 not directly accessible from the dialog root, but accessible from other dialogues. On a screenshot a situation after were inserted into a tree a state 33 and the response 44.

If such dialog is not found, the element is added under one of nodes -- **"Orphan nodes" / "Orphan responses"**. At the same time for response at first tries the first state which refers to it and if it is absent then it inserted under "Orphan responses":
![Orphan states and responses](https://user-images.githubusercontent.com/450131/59556006-31557180-8fd5-11e9-9858-fd1d3d56ed75.png)
