### PR TITLE
Normalize kit search appearance

### DIFF
--- a/src/org/infinity/datatype/IdsBitmap.java
+++ b/src/org/infinity/datatype/IdsBitmap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.datatype;
@@ -47,34 +47,22 @@ public class IdsBitmap extends HashBitmap
     super(parent, buffer, offset, length, name, createResourceList(resource, idsStart, idsSize), true);
   }
 
-  public int getIdsMapEntryCount()
+  @Override
+  @SuppressWarnings("unchecked")
+  public LongIntegerHashMap<IdsMapEntry> getHashBitmap()
   {
-    return getHashBitmap().size();
+    return (LongIntegerHashMap<IdsMapEntry>)super.getHashBitmap();
   }
 
-  public IdsMapEntry getIdsMapEntryByIndex(int index)
-  {
-    if (index >= 0 && index < getHashBitmap().size()) {
-      return (IdsMapEntry)getHashBitmap().get(getHashBitmap().keys()[index]);
-    } else {
-      return null;
-    }
-  }
-
-  public IdsMapEntry getIdsMapEntryById(long id)
-  {
-    return (IdsMapEntry)getHashBitmap().get(Long.valueOf(id));
-  }
-
+  /**
+   * Add to bitmap specified entry, id entry with such key not yet registered,
+   * otherwise do nothing.
+   *
+   * @param entry Entry to add. Must not be {@code null}
+   */
   public void addIdsMapEntry(IdsMapEntry entry)
   {
-    if (entry != null) {
-      @SuppressWarnings("unchecked")
-      LongIntegerHashMap<IdsMapEntry>map = (LongIntegerHashMap<IdsMapEntry>)getHashBitmap();
-      if (!map.containsKey(Long.valueOf(entry.getID()))) {
-        map.put(Long.valueOf(entry.getID()), entry);
-      }
-    }
+    getHashBitmap().putIfAbsent(entry.getID(), entry);
   }
 
   private static LongIntegerHashMap<IdsMapEntry> createResourceList(String resource, int idsStart, int idsSize)
@@ -82,12 +70,12 @@ public class IdsBitmap extends HashBitmap
     LongIntegerHashMap<IdsMapEntry> retVal = null;
     IdsMap idsMap = IdsMapCache.get(resource);
     if (idsMap != null) {
-      retVal = new LongIntegerHashMap<IdsMapEntry>();
+      retVal = new LongIntegerHashMap<>();
       for (final IdsMapEntry e: idsMap.getAllValues()) {
         long id = e.getID();
         if (idsSize < 0 || (id >= idsStart && id < idsStart + idsSize)) {
           id -= idsStart;
-          retVal.put(Long.valueOf(id), new IdsMapEntry(id, e.getSymbol()));
+          retVal.put(id, new IdsMapEntry(id, e.getSymbol()));
         }
       }
 
@@ -103,4 +91,3 @@ public class IdsBitmap extends HashBitmap
     return retVal;
   }
 }
-

--- a/src/org/infinity/search/SearchResource.java
+++ b/src/org/infinity/search/SearchResource.java
@@ -1235,7 +1235,7 @@ public class SearchResource extends ChildFrame
 
     public int getOptionAnimation()
     {
-      return Utils.getIdsValue(cbOptions[ID_Animation].isSelected(), cbAnimation.getSelectedItem());
+      return Utils.getIdsValue(cbOptions[ID_Animation], cbAnimation);
     }
 
 
@@ -1300,8 +1300,7 @@ public class SearchResource extends ChildFrame
       pScripts = new CreScriptsPanel(3);
       bpwScripts = new ButtonPopupWindow(setOptionsText, pScripts);
 
-      cbAnimation = new AutoComboBox<>(Utils.getIdsMapEntryList(
-          new IdsBitmap(StreamUtils.getByteBuffer(4), 0, 4, "Animation", "ANIMATE.IDS")));
+      cbAnimation = Utils.getIdsMapEntryList(4, "Animation", "ANIMATE.IDS");
       cbAnimation.setPreferredSize(Utils.getPrototypeSize(cbAnimation));
 
       pGameSpecific = new CreGameSpecificPanel();
@@ -4426,6 +4425,7 @@ public class SearchResource extends ChildFrame
                                                        "Allegiance:", "Kit:", "Sex:"};
 
     private final JCheckBox[] cbLabel = new JCheckBox[EntryCount];
+    /** Each combobox contains list of {@link IdsMapEntry}. */
     private final JComboBox<?>[] cbType = new JComboBox[EntryCount];
 
     public CreTypePanel()
@@ -4472,12 +4472,7 @@ public class SearchResource extends ChildFrame
     public int getOptionType(int id)
     {
       if (id < 0) id = 0; else if (id >= EntryCount) id = EntryCount - 1;
-      if (cbType[id].getSelectedItem() instanceof StorageString) {
-        return cbLabel[id].isSelected() ?
-            (Integer)((StorageString)cbType[id].getSelectedItem()).getObject() : 0;
-      } else {
-        return Utils.getIdsValue(cbLabel[id].isSelected(), cbType[id].getSelectedItem());
-      }
+      return Utils.getIdsValue(cbLabel[id], cbType[id]);
     }
 
 
@@ -4496,53 +4491,24 @@ public class SearchResource extends ChildFrame
       }
       cbLabel[TYPE_KIT].setEnabled(hasKit);
 
-      final int defaultSize = 160;
-      cbType[TYPE_GENERAL] = Utils.defaultWidth(
-          new AutoComboBox<>(Utils.getIdsMapEntryList(
-              new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "General", "GENERAL.IDS"))), defaultSize);
-      cbType[TYPE_CLASS] = Utils.defaultWidth(
-          new AutoComboBox<>(Utils.getIdsMapEntryList(
-              new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "Class", "CLASS.IDS"))), defaultSize);
-      cbType[TYPE_SPECIFICS] = Utils.defaultWidth(
-          new AutoComboBox<>(Utils.getIdsMapEntryList(
-              new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "Specifics", "SPECIFIC.IDS"))), defaultSize);
-      String idsFile = Profile.getProperty(Profile.Key.GET_IDS_ALIGNMENT);
-      cbType[TYPE_ALIGNMENT] = Utils.defaultWidth(
-          new AutoComboBox<>(Utils.getIdsMapEntryList(
-              new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "Alignment", idsFile))), defaultSize);
-      cbType[TYPE_GENDER] = Utils.defaultWidth(
-          new AutoComboBox<>(Utils.getIdsMapEntryList(
-              new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "Gender", "GENDER.IDS"))), defaultSize);
-      cbType[TYPE_RACE] = Utils.defaultWidth(
-          new AutoComboBox<>(Utils.getIdsMapEntryList(
-              new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "Race", "RACE.IDS"))), defaultSize);
-      cbType[TYPE_ALLEGIANCE] = Utils.defaultWidth(
-          new AutoComboBox<>(Utils.getIdsMapEntryList(
-              new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "Allegiance", "EA.IDS"))), defaultSize);
+      final String alignmentIDS = Profile.getProperty(Profile.Key.GET_IDS_ALIGNMENT);
+      cbType[TYPE_GENERAL]    = Utils.getIdsMapEntryList(1, "General",    "GENERAL.IDS");
+      cbType[TYPE_CLASS]      = Utils.getIdsMapEntryList(1, "Class",      "CLASS.IDS");
+      cbType[TYPE_SPECIFICS]  = Utils.getIdsMapEntryList(1, "Specifics",  "SPECIFIC.IDS");
+      cbType[TYPE_ALIGNMENT]  = Utils.getIdsMapEntryList(1, "Alignment",  alignmentIDS);
+      cbType[TYPE_GENDER]     = Utils.getIdsMapEntryList(1, "Gender",     "GENDER.IDS");
+      cbType[TYPE_RACE]       = Utils.getIdsMapEntryList(1, "Race",       "RACE.IDS");
+      cbType[TYPE_ALLEGIANCE] = Utils.getIdsMapEntryList(1, "Allegiance", "EA.IDS");
 
-      final StorageString[] kitList;
       if (Profile.getEngine() == Profile.Engine.IWD2) {
-        IdsMapEntry[] ids = Utils.getIdsMapEntryList(
-            new IdsBitmap(StreamUtils.getByteBuffer(1), 0, 1, "Allegiance", "KIT.IDS"));
-        kitList = new StorageString[ids.length];
-        for (int i = 0; i < kitList.length; i++) {
-          kitList[i] = new ObjectString(ids[i].getSymbol(), (int)ids[i].getID());
-        }
-      } else if (hasKit) {
-        final KitIdsBitmap kit = new KitIdsBitmap(StreamUtils.getByteBuffer(4), 0, "");
-        final SortedMap<Long, IdsMapEntry> map = kit.getHashBitmap();
-
-        kitList = new StorageString[map.size()];
-        int i = 0;
-        for (final Map.Entry<Long, IdsMapEntry> e : map.entrySet()) {
-          final IdsMapEntry value = e.getValue();
-          kitList[i] = new ObjectString(value.getSymbol(), (int)value.getID());
-          ++i;
-        }
+        cbType[TYPE_KIT] = Utils.getIdsMapEntryList(1, "Kit", "KIT.IDS");
+      } else
+      if (hasKit) {
+        final KitIdsBitmap kit = new KitIdsBitmap(StreamUtils.getByteBuffer(4), 0, "Kit");
+        cbType[TYPE_KIT] = Utils.getIdsMapEntryList(kit);
       } else {
-        kitList = new StorageString[]{};
+        cbType[TYPE_KIT] = new AutoComboBox<>(new IdsMapEntry[0]);
       }
-      cbType[TYPE_KIT] = Utils.defaultWidth(new AutoComboBox<>(kitList), defaultSize);
       cbType[TYPE_KIT].setEnabled(hasKit);
 
       // placing components
@@ -6459,31 +6425,33 @@ public class SearchResource extends ChildFrame
       return spinner;
     }
 
-    /** Returns the ID of the IDS value specified by "value". */
-    public static int getIdsValue(boolean enabled, Object value)
+    /**
+     * Returns the ID of the IDS value specified by current selected item in {@code value}.
+     *
+     * @param enabled If not checked, method returns 0
+     * @param value Combobox with selectable values. If none selected, method returns 0
+     */
+    public static int getIdsValue(JCheckBox enabled, JComboBox<?> value)
     {
-      if (enabled && value != null) {
-        if (value instanceof IdsMapEntry) {
-          return (int)((IdsMapEntry)value).getID();
-        } else {
-          try {
-            return Integer.parseInt(value.toString());//FIXME: Smell code
-          } catch (NumberFormatException e) {
-          }
-        }
+      if (enabled.isSelected()) {
+        final IdsMapEntry selected = (IdsMapEntry)value.getSelectedItem();
+        return (int)selected.getID();
       }
       return 0;
     }
 
-    public static IdsMapEntry[] getIdsMapEntryList(IdsBitmap ids)
+    public static JComboBox<IdsMapEntry> getIdsMapEntryList(int bufSize, String name, String idsResourceName)
     {
-      if (ids != null) {
-        final SortedMap<Long, IdsMapEntry> map = ids.getHashBitmap();
-        final IdsMapEntry[] list = map.values().toArray(new IdsMapEntry[map.size()]);
-        Arrays.sort(list);
-        return list;
-      }
-      return new IdsMapEntry[0];
+      final IdsBitmap ids = new IdsBitmap(StreamUtils.getByteBuffer(bufSize), 0, bufSize, name, idsResourceName);
+      return getIdsMapEntryList(ids);
+    }
+
+    public static JComboBox<IdsMapEntry> getIdsMapEntryList(IdsBitmap ids)
+    {
+      final SortedMap<Long, IdsMapEntry> map = ids.getHashBitmap();
+      final IdsMapEntry[] list = map.values().toArray(new IdsMapEntry[map.size()]);
+      Arrays.sort(list);
+      return defaultWidth(new AutoComboBox<>(list), 160);
     }
 
     /** Returns list's index of o */

--- a/src/org/infinity/search/SearchResource.java
+++ b/src/org/infinity/search/SearchResource.java
@@ -3725,11 +3725,6 @@ public class SearchResource extends ChildFrame
       return Utils.getRangeValues(cbLabel[id].isSelected(), sEffects[id]);
     }
 
-//    public int getOptionEffectCount()
-//    {
-//      return entryCount;
-//    }
-
     private void init()
     {
       // initializing components
@@ -3769,7 +3764,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -3918,11 +3912,6 @@ public class SearchResource extends ChildFrame
       }
       return null;
     }
-
-//    public int getOptionFilterCount()
-//    {
-//      return entryCount;
-//    }
 
     private JPanel createFilterPanel(int entry, int type)
     {
@@ -4082,7 +4071,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -4299,7 +4287,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -4417,7 +4404,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -4583,7 +4569,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -4708,7 +4693,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -4772,11 +4756,6 @@ public class SearchResource extends ChildFrame
       return Utils.getResourceName(cbItems[id].isEnabled(),
           (ResourceEntry)((NamedResourceEntry)cbItems[id].getSelectedItem()).getResourceEntry());
     }
-
-//    public int getOptionItemCount()
-//    {
-//      return entryCount;
-//    }
 
     private void init()
     {
@@ -4881,11 +4860,6 @@ public class SearchResource extends ChildFrame
           (ResourceEntry)((NamedResourceEntry)cbSpells[id].getSelectedItem()).getResourceEntry());
     }
 
-//    public int getOptionSpellCount()
-//    {
-//      return entryCount;
-//    }
-
     private void init()
     {
       // initializing components
@@ -4989,11 +4963,6 @@ public class SearchResource extends ChildFrame
       return Utils.getResourceName(cbScripts[id].isEnabled(),
           (ResourceEntry)((NamedResourceEntry)cbScripts[id].getSelectedItem()).getResourceEntry());
     }
-
-//    public int getOptionScriptCount()
-//    {
-//      return entryCount;
-//    }
 
     private void init()
     {
@@ -5165,7 +5134,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -6028,11 +5996,6 @@ public class SearchResource extends ChildFrame
       return 0;
     }
 
-//    public int getOptionPurchasedCount()
-//    {
-//      return entryCount;
-//    }
-
     private void init()
     {
       for (int i = 0; i < entryCount; i++) {
@@ -6138,11 +6101,6 @@ public class SearchResource extends ChildFrame
           (ResourceEntry)((NamedResourceEntry)cbItems[index].getSelectedItem()).getResourceEntry());
     }
 
-//    public int getOptionItemCount()
-//    {
-//      return entryCount;
-//    }
-
     private void init()
     {
       for (int i = 0; i < entryCount; i++) {
@@ -6181,7 +6139,6 @@ public class SearchResource extends ChildFrame
       pMain.add(panel, c);
       add(pMain, BorderLayout.CENTER);
     }
-
   }
 
 
@@ -6316,11 +6273,6 @@ public class SearchResource extends ChildFrame
       return entry;
     }
 
-//    public String getResourceName()
-//    {
-//      return (resName != null) ? resName : "";
-//    }
-
     @Override
     public String toString()
     {
@@ -6371,18 +6323,6 @@ public class SearchResource extends ChildFrame
       this.maxLength = (maxLength > 0) ? maxLength : Integer.MAX_VALUE;
       this.upperCase = upperCase;
     }
-
-//    /** Returns max. number of characters of content allowed for the document. */
-//    public int getMaxLength()
-//    {
-//      return maxLength;
-//    }
-
-//    /** Returns whether the document converts all characters into uppercase versions */
-//    public boolean isUpperCase()
-//    {
-//      return upperCase;
-//    }
 
     @Override
     public void insertString(int off, String str, AttributeSet a) throws BadLocationException
@@ -6480,18 +6420,6 @@ public class SearchResource extends ChildFrame
         }
       }
     }
-
-    // Returns whether auto update has been enabled
-//    private static boolean setSpinnerAutoUpdate(JSpinner spinner)
-//    {
-//      if (spinner != null) {
-//        JFormattedTextField ftf = (JFormattedTextField)spinner.getEditor().getComponent(0);
-//        if (ftf != null) {
-//          return ((DefaultFormatter)ftf.getFormatter()).getCommitsOnValidEdit();
-//        }
-//      }
-//      return false;
-//    }
 
     /** Сreates a "min" to "max" panel. */
     public static JPanel createNumberRangePanel(JSpinner min, JSpinner max)
@@ -6612,32 +6540,9 @@ public class SearchResource extends ChildFrame
   /** Adds "auto-select item" feature to JComboBox. */
   public static class AutoComboBox<E> extends JComboBox<E>
   {
-    public AutoComboBox()
-    {
-      super();
-      init();
-    }
-
-    public AutoComboBox(ComboBoxModel<E> aModel)
-    {
-      super(aModel);
-      init();
-    }
-
     public AutoComboBox(E[] items)
     {
       super(items);
-      init();
-    }
-
-    public AutoComboBox(Vector<E> items)
-    {
-      super(items);
-      init();
-    }
-
-    private void init()
-    {
       setEditable(true);
       new AutoDocument<>(this);
     }

--- a/src/org/infinity/search/SearchResource.java
+++ b/src/org/infinity/search/SearchResource.java
@@ -291,7 +291,7 @@ public class SearchResource extends ChildFrame
 
   // --------------------- End Interface Runnable ---------------------
 
-  // initialize dialog
+  /** Initialize dialog. */
   private void init() throws Exception
   {
     int progress = 1;
@@ -528,7 +528,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // returns whether any option has been selected in the current options panel
+  /** Returns whether any option has been selected in the current options panel. */
   private boolean isOptionsEmpty()
   {
     String type = getCurrentResourceType();
@@ -539,7 +539,7 @@ public class SearchResource extends ChildFrame
     return true;
   }
 
-  // Returns the resource type (as file extension) of the current selection
+  /** Returns the resource type (as file extension) of the current selection. */
   private String getCurrentResourceType()
   {
     ObjectString os = (ObjectString)cbResourceType.getSelectedItem();
@@ -552,7 +552,7 @@ public class SearchResource extends ChildFrame
 
 //-------------------------- INNER CLASSES --------------------------
 
-  // Worker class for threaded searching resources
+  /** Worker class for threaded searching resources. */
   private class SearchWorker implements Runnable
   {
     private final List<NamedResourceEntry> list;
@@ -3488,7 +3488,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // common base class for popup windows
+  /** Common base class for popup windows. */
   private static abstract class BasePanel extends JPanel implements ActionListener
   {
     /** Returns true if no option has been selected. */
@@ -3511,7 +3511,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify flags
+  /** Creates a dialog that allows to specify flags. */
   private static final class FlagsPanel extends BasePanel implements ActionListener
   {
     private final int size;
@@ -3662,7 +3662,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify effect opcodes for CRE resources
+  /** Creates a dialog that allows to specify effect opcodes for CRE resources. */
   private static final class EffectsPanel extends BasePanel implements ActionListener
   {
     private static final int MaxEntryCount     = 16;
@@ -3773,7 +3773,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify custom filters for the selected resource type
+  /** Creates a dialog that allows to specify custom filters for the selected resource type. */
   private static final class CustomFilterPanel extends BasePanel implements ActionListener
   {
     private static final int FILTER_STRING    = 0;
@@ -4086,7 +4086,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify spell effect timing modes
+  /** Creates a dialog that allows to specify spell effect timing modes. */
   private static final class TimingModePanel extends BasePanel implements ActionListener
   {
     public static final int TIMING_MODE     = 0;
@@ -4200,7 +4200,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify creature level ranges
+  /** Creates a dialog that allows to specify creature level ranges. */
   private static final class CreLevelPanel extends BasePanel implements ActionListener
   {
     private static final String[] label =
@@ -4303,7 +4303,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify creature level ranges (IWD2-specific)
+  /** Creates a dialog that allows to specify creature level ranges (IWD2-specific). */
   private static final class CreLevelIWD2Panel extends BasePanel implements ActionListener
   {
     public static final int LEVEL_TOTAL     = 0;
@@ -4421,7 +4421,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify creature types
+  /** Creates a dialog that allows to specify creature types. */
   private static final class CreTypePanel extends BasePanel implements ActionListener
   {
     public static final int TYPE_GENERAL    = 0;
@@ -4587,7 +4587,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify game-specific settings for CRE resources
+  /** Creates a dialog that allows to specify game-specific settings for CRE resources. */
   private static final class CreGameSpecificPanel extends BasePanel implements ActionListener
   {
     public static final int TYPE_FEATS1     = 0;
@@ -4712,7 +4712,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify inventory items for CRE resources
+  /** Creates a dialog that allows to specify inventory items for CRE resources. */
   private static final class CreItemsPanel extends BasePanel implements ActionListener
   {
     private static final int MaxEntryCount     = 16;
@@ -4820,7 +4820,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify spells for CRE resources
+  /** Creates a dialog that allows to specify spells for CRE resources. */
   private static final class CreSpellsPanel extends BasePanel implements ActionListener
   {
     private static final int MaxEntryCount     = 16;
@@ -4929,7 +4929,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify spells for CRE resources
+  /** Creates a dialog that allows to specify spells for CRE resources. */
   private static final class CreScriptsPanel extends BasePanel implements ActionListener
   {
     private static final int MaxEntryCount     = 8;
@@ -5038,7 +5038,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify usability flags
+  /** Creates a dialog that allows to specify usability flags. */
   private static final class ItmUsabilityPanel extends BasePanel implements ActionListener
   {
     public static final int ITEM_UNUSABLE       = 0;
@@ -5169,7 +5169,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify minimum stats ranges
+  /** Creates a dialog that allows to specify minimum stats ranges. */
   private static final class ItmStatsPanel extends BasePanel implements ActionListener
   {
     // supported stats
@@ -5296,7 +5296,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify item ability properties
+  /** Creates a dialog that allows to specify item ability properties. */
   private static final class ItmAbilityPanel extends BasePanel implements ActionListener
   {
     private static final  int ITEM_TYPE       = 0;
@@ -5683,7 +5683,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify spell ability properties
+  /** Creates a dialog that allows to specify spell ability properties. */
   private static final class SplAbilityPanel extends BasePanel implements ActionListener
   {
     private static final int SPELL_TYPE       = 0;
@@ -5962,7 +5962,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify item categories allowed in STO resources
+  /** Creates a dialog that allows to specify item categories allowed in STO resources. */
   private static final class StoCategoriesPanel extends BasePanel implements ActionListener
   {
     private static final int MaxEntryCount = 16;
@@ -6077,7 +6077,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // creates a dialog that allows to specify items provided by stores
+  /** Creates a dialog that allows to specify items provided by stores. */
   private static final class StoForSalePanel extends BasePanel implements ActionListener
   {
     private static final int MaxEntryCount = 16;
@@ -6185,7 +6185,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // common base for IndexedString and ObjectString
+  /** Common base for {@link IndexedString} and {@link ObjectString}. */
   private interface StorageString
   {
     public String getString();
@@ -6297,7 +6297,7 @@ public class SearchResource extends ChildFrame
     }
   }
 
-  // Simple wrapper for ResourceEntry structures to provide a more informative description
+  /** Simple wrapper for ResourceEntry structures to provide a more informative description. */
   private static final class NamedResourceEntry implements Comparable<NamedResourceEntry>
   {
     private static final String NONE = "None";
@@ -6359,7 +6359,7 @@ public class SearchResource extends ChildFrame
   }
 
 
-  // Controls the maximum string length of text input components
+  /** Controls the maximum string length of text input components. */
   private static final class FormattedDocument extends PlainDocument
   {
     private final int maxLength;
@@ -6402,10 +6402,10 @@ public class SearchResource extends ChildFrame
 
   private static final class Utils
   {
-    // can be used to determine the preferred size of a combobox
+    /** Can be used to determine the preferred size of a combobox. */
     public static final String ProtoTypeString = "XXXXXXXX.XXXX (XXXXXXXXXXXX)";
 
-    // use for sorting by resource filename
+    /** Use for sorting by resource filename. */
     public static final Comparator<NamedResourceEntry> NamedResourceComparator = new Comparator<NamedResourceEntry>() {
       @Override
       public int compare(NamedResourceEntry e1, NamedResourceEntry e2) {
@@ -6413,7 +6413,7 @@ public class SearchResource extends ChildFrame
       }
     };
 
-    // returns a (sorted or unsorted) list of resource names, first entry is the special "None" entry
+    /** Returns a (sorted or unsorted) list of resource names, first entry is the special "None" entry. */
     public static Vector<NamedResourceEntry> createNamedResourceList(String[] extensions, boolean sort)
     {
       Vector<NamedResourceEntry> list = new Vector<NamedResourceEntry>();
@@ -6437,7 +6437,7 @@ public class SearchResource extends ChildFrame
       return list;
     }
 
-    // returns a combobox containing all available resource of specified extensions
+    /** Returns a combobox containing all available resource of specified extensions. */
     public static JComboBox<NamedResourceEntry> createNamedResourceComboBox(String[] extensions, boolean usePrototype)
     {
       Vector<NamedResourceEntry> names = createNamedResourceList(extensions, false);
@@ -6470,7 +6470,7 @@ public class SearchResource extends ChildFrame
       return component;
     }
 
-    // Enable or disable whether to automatically update the spinner value while typing
+    /** Enable or disable whether to automatically update the spinner value while typing. */
     private static void setSpinnerAutoUpdate(JSpinner spinner, boolean enable)
     {
       if (spinner != null) {
@@ -6493,7 +6493,7 @@ public class SearchResource extends ChildFrame
 //      return false;
 //    }
 
-    // creates a "min" to "max" panel
+    /** Сreates a "min" to "max" panel. */
     public static JPanel createNumberRangePanel(JSpinner min, JSpinner max)
     {
       GridBagConstraints c = new GridBagConstraints();
@@ -6643,7 +6643,7 @@ public class SearchResource extends ChildFrame
     }
   }
 
-  /** Implements the auto-selection of items for {@link #AutoComboBox}. */
+  /** Implements the auto-selection of items for {@link AutoComboBox}. */
   private static class AutoDocument<E> extends PlainDocument
   {
     private final FocusListener editorFocusListener;
@@ -6752,7 +6752,7 @@ public class SearchResource extends ChildFrame
       }
     }
 
-    // Attempts to find a matching item from the list
+    /** Attempts to find a matching item from the list. */
     private Object lookupItem(String pattern)
     {
       if (pattern != null && !pattern.isEmpty()) {
@@ -6772,7 +6772,7 @@ public class SearchResource extends ChildFrame
       return null;
     }
 
-    // Compares the item with the pattern, returns true if a (partial) match has been found
+    /** Compares the item with the pattern, returns true if a (partial) match has been found. */
     private boolean compareItem(Object item, String pattern)
     {
       if (item != null && pattern != null && !pattern.isEmpty()) {
@@ -6813,7 +6813,7 @@ public class SearchResource extends ChildFrame
       return false;
     }
 
-    // sets the editor text to the given string
+    /** Sets the editor text to the given string. */
     private void setText(String text)
     {
       try {
@@ -6825,14 +6825,14 @@ public class SearchResource extends ChildFrame
       }
     }
 
-    // highlights the editor text, starting at the given offset
+    /** Highlights the editor text, starting at the given offset. */
     private void highlightCompletedText(int start)
     {
       editor.setCaretPosition(getLength());
       editor.moveCaretPosition(start);
     }
 
-    // selects the specified item without triggering certain events
+    /** Selects the specified item without triggering certain events. */
     private void setSelectedItem(Object item)
     {
       selecting = true;
@@ -6843,7 +6843,7 @@ public class SearchResource extends ChildFrame
       }
     }
 
-    // prevent certain GUI themes to select the whole text automatically
+    /** Prevent certain GUI themes to select the whole text automatically. */
     private void updateCursor()
     {
       int offs = editor.getCaretPosition();

--- a/src/org/infinity/util/LongIntegerHashMap.java
+++ b/src/org/infinity/util/LongIntegerHashMap.java
@@ -1,5 +1,5 @@
 // Near Infinity - An Infinity Engine Browser and Editor
-// Copyright (C) 2001 - 2005 Jon Olav Hauglid
+// Copyright (C) 2001 - 2019 Jon Olav Hauglid
 // See LICENSE.txt for license information
 
 package org.infinity.util;
@@ -14,23 +14,6 @@ public final class LongIntegerHashMap<V> extends TreeMap<Long, V>
   public LongIntegerHashMap()
   {
     super();
-  }
-
-  public LongIntegerHashMap(Map<Long, ? extends V> m)
-  {
-    super(m);
-  }
-
-  public long[] keys()
-  {
-    Set<Long> set = keySet();
-    long[] result = new long[set.size()];
-    Iterator<Long> iter = set.iterator();
-    int i = 0;
-    while (iter.hasNext() && i < result.length) {
-      result[i++] = iter.next().longValue();
-    }
-    return result;
   }
 
   @Override


### PR DESCRIPTION
The appearance of the filter by **Kit** in Creatures extended search differs from other filters a little. It is because for the inexplicable reason its processing is made differently, than other filters by IDS values. Now it is corrected.

Before (on BG2 example):
![Before - BG2](https://user-images.githubusercontent.com/450131/60396935-fa4c9780-9b60-11e9-915b-4cd600787294.png)
After:
![After - BG2](https://user-images.githubusercontent.com/450131/60396936-fa4c9780-9b60-11e9-9fcd-74253ea4df9a.png)
