### PR TITLE
Fix non-transparent images in BAM Converter

### DIFF
--- a/src/org/infinity/gui/converter/ConvertToBam.java
+++ b/src/org/infinity/gui/converter/ConvertToBam.java
@@ -2674,8 +2674,9 @@ public class ConvertToBam extends ChildFrame implements ActionListener, Property
             image = dstImage;
           }
 
-          modelFrames.insert(listIndex + curFrameIdx, image, new Point(),
-            image.getType() != BufferedImage.TYPE_BYTE_INDEXED);
+          // Workaround for BAMV1 transparency, see PseudoBamDecoder.OPTION_BOOL_TRANSPARENTGREENFORCED
+          final boolean forceTransparentGreen = image.getType() != BufferedImage.TYPE_BYTE_INDEXED;
+          modelFrames.insert(listIndex + curFrameIdx, image, new Point(), forceTransparentGreen);
           // setting required extra options
           PseudoBamFrameEntry fe2 = modelFrames.getDecoder().getFrameInfo(listIndex + curFrameIdx);
           if (entry instanceof FileResourceEntry) {

--- a/src/org/infinity/gui/converter/ConvertToBam.java
+++ b/src/org/infinity/gui/converter/ConvertToBam.java
@@ -2674,7 +2674,8 @@ public class ConvertToBam extends ChildFrame implements ActionListener, Property
             image = dstImage;
           }
 
-          modelFrames.insert(listIndex + curFrameIdx, image, new Point());
+          modelFrames.insert(listIndex + curFrameIdx, image, new Point(),
+            image.getType() != BufferedImage.TYPE_BYTE_INDEXED);
           // setting required extra options
           PseudoBamFrameEntry fe2 = modelFrames.getDecoder().getFrameInfo(listIndex + curFrameIdx);
           if (entry instanceof FileResourceEntry) {
@@ -4486,11 +4487,16 @@ public class ConvertToBam extends ChildFrame implements ActionListener, Property
 
     /** Inserts the image into the global frames list. */
     public void insert(int pos, BufferedImage image, Point center) {
-      insert(pos, new BufferedImage[] { image }, new Point[] { center });
+      insert(pos, image, center, false);
+    }
+
+    /** Inserts the image into the global frames list. */
+    public void insert(int pos, BufferedImage image, Point center, boolean forceTransparentGreen) {
+      insert(pos, new BufferedImage[] { image }, new Point[] { center }, forceTransparentGreen);
     }
 
     /** Inserts the array of images into the global frames list. */
-    public void insert(int pos, BufferedImage[] images, Point[] centers) {
+    public void insert(int pos, BufferedImage[] images, Point[] centers, boolean forceTransparentGreen) {
       if (images != null && pos >= 0 && pos <= getDecoder().frameCount()) {
         int count = 0;
         PseudoBamControl control = getDecoder().createControl();
@@ -4499,10 +4505,13 @@ public class ConvertToBam extends ChildFrame implements ActionListener, Property
           if (images[i] != null) {
             // adding frame to global list
             Point center = (centers.length > i && centers[i] != null) ? centers[i] : null;
-            getDecoder().frameInsert(pos + i, images[i], center);
+            final int frameIdx = pos + i;
+            getDecoder().frameInsert(frameIdx, images[i], center);
+            getDecoder().getFrameInfo(frameIdx).setOption(PseudoBamDecoder.OPTION_BOOL_TRANSPARENTGREENFORCED,
+              forceTransparentGreen);
             // registering colors values in global HashMap
             BufferedImage image = ColorConvert.toBufferedImage(images[i], true, false);
-            PseudoBamDecoder.registerColors(getConverter().paletteDialog.getColorMap(), image);
+            PseudoBamDecoder.registerColors(getConverter().paletteDialog.getColorMap(), image, forceTransparentGreen);
             getConverter().paletteDialog.setPaletteModified();
             count++;
           }
@@ -4538,8 +4547,10 @@ public class ConvertToBam extends ChildFrame implements ActionListener, Property
         control.setMode(BamDecoder.BamControl.Mode.INDIVIDUAL);
         // unregistering color values in global color map
         for (int i = 0; i < count; i++) {
-          BufferedImage image = ColorConvert.toBufferedImage(getDecoder().frameGet(control, pos + i), true, false);
-          PseudoBamDecoder.unregisterColors(getConverter().paletteDialog.getColorMap(), image);
+          final int frameIdx = pos + i;
+          BufferedImage image = ColorConvert.toBufferedImage(getDecoder().frameGet(control, frameIdx), true, false);
+          PseudoBamDecoder.unregisterColors(getConverter().paletteDialog.getColorMap(), image, (boolean)getDecoder()
+            .getFrameInfo(frameIdx).getOption(PseudoBamDecoder.OPTION_BOOL_TRANSPARENTGREENFORCED));
           getConverter().paletteDialog.setPaletteModified();
         }
         getDecoder().frameRemove(pos, count);

--- a/src/org/infinity/resource/graphics/PseudoBamDecoder.java
+++ b/src/org/infinity/resource/graphics/PseudoBamDecoder.java
@@ -58,6 +58,9 @@ public class PseudoBamDecoder extends BamDecoder {
    * Index 0 of a BAMV1 colormap is special: If the transparent green color (0,255,0) is NOT present in the colormap,
    * index 0 is treated as transparent. For non-transparent, non-paletted source images we need to ensure (0,255,0) is
    * present in the final colormap, as to prevent a normal color in index 0 from incorrectly rendering as transparent.
+   *
+   * @see <a href="https://gibberlings3.github.io/iesdp/file_formats/ie_formats/bam_v1.htm#bamv1_Header">
+   * BAM V1 Header</a> - Offset 0x000b
    */
   public static final String OPTION_BOOL_TRANSPARENTGREENFORCED = "TransparentGreenForced";
 

--- a/src/org/infinity/resource/graphics/PseudoBamDecoder.java
+++ b/src/org/infinity/resource/graphics/PseudoBamDecoder.java
@@ -1134,8 +1134,8 @@ public class PseudoBamDecoder extends BamDecoder {
           colorMap.put(key, count);
         }
       }
-      if (forceTransparentGreen && !colorMap.containsKey(Green)) {
-        colorMap.put(Green, 1);
+      if (forceTransparentGreen) {
+        colorMap.put(Green, colorMap.getOrDefault(Green, 0) + 1);
       }
     }
   }
@@ -1195,8 +1195,16 @@ public class PseudoBamDecoder extends BamDecoder {
           }
         }
       }
-      if (forcedTransparentGreen && colorMap.get(Green) == 1) {
-        colorMap.remove(Green);
+      if (forcedTransparentGreen) {
+        Integer count = colorMap.get(Green);
+        if (count != null) {
+          --count;
+          if (count == 0) {
+            colorMap.remove(Green);
+          } else {
+            colorMap.put(Green, count);
+          }
+        }
       }
     }
   }

--- a/src/org/infinity/resource/graphics/PseudoBamDecoder.java
+++ b/src/org/infinity/resource/graphics/PseudoBamDecoder.java
@@ -51,7 +51,14 @@ public class PseudoBamDecoder extends BamDecoder {
   /** A value specifying a compressed pixel value. (BAM v1 specific) [Integer] */
   public static final String OPTION_INT_RLEINDEX = "RLEIndex";
 
-  /** A value specifying if the transparent green color has been forced into the colormap (BAM v1 specific) [Boolean] */
+  /**
+   * A value specifying if the transparent green color (0,255,0) has been forced into the colormap
+   * (BAM v1 specific) [Boolean]
+   * <br><br>
+   * Index 0 of a BAMV1 colormap is special: If the transparent green color (0,255,0) is NOT present in the colormap,
+   * index 0 is treated as transparent. For non-transparent, non-paletted source images we need to ensure (0,255,0) is
+   * present in the final colormap, as to prevent a normal color in index 0 from incorrectly rendering as transparent.
+   */
   public static final String OPTION_BOOL_TRANSPARENTGREENFORCED = "TransparentGreenForced";
 
   /** A value specifying the start index of data blocks (BAM v2 specific) [Integer] */
@@ -1134,6 +1141,7 @@ public class PseudoBamDecoder extends BamDecoder {
           colorMap.put(key, count);
         }
       }
+      // Workaround for BAMV1 transparency, see PseudoBamDecoder.OPTION_BOOL_TRANSPARENTGREENFORCED
       if (forceTransparentGreen) {
         colorMap.put(Green, colorMap.getOrDefault(Green, 0) + 1);
       }
@@ -1195,6 +1203,7 @@ public class PseudoBamDecoder extends BamDecoder {
           }
         }
       }
+      // Workaround for BAMV1 transparency, see PseudoBamDecoder.OPTION_BOOL_TRANSPARENTGREENFORCED
       if (forcedTransparentGreen) {
         Integer count = colorMap.get(Green);
         if (count != null) {

--- a/src/org/infinity/resource/graphics/PseudoBamDecoder.java
+++ b/src/org/infinity/resource/graphics/PseudoBamDecoder.java
@@ -51,6 +51,9 @@ public class PseudoBamDecoder extends BamDecoder {
   /** A value specifying a compressed pixel value. (BAM v1 specific) [Integer] */
   public static final String OPTION_INT_RLEINDEX = "RLEIndex";
 
+  /** A value specifying if the transparent green color has been forced into the colormap (BAM v1 specific) [Boolean] */
+  public static final String OPTION_BOOL_TRANSPARENTGREENFORCED = "TransparentGreenForced";
+
   /** A value specifying the start index of data blocks (BAM v2 specific) [Integer] */
   public static final String OPTION_INT_BLOCKINDEX = "BlockIndex";
 
@@ -1032,7 +1035,7 @@ public class PseudoBamDecoder extends BamDecoder {
       if (colorMap == null) {
         newMap = new HashMap<>();
         for (PseudoBamFrameEntry listFrame : listFrames) {
-          registerColors(newMap, listFrame.frame);
+          registerColors(newMap, listFrame.frame, (boolean)listFrame.getOption(OPTION_BOOL_TRANSPARENTGREENFORCED));
         }
       } else {
         newMap = new HashMap<>(colorMap.size());
@@ -1084,7 +1087,7 @@ public class PseudoBamDecoder extends BamDecoder {
   }
 
   /** Maps all color values of the specified image. */
-  public static void registerColors(HashMap<Integer, Integer> colorMap, BufferedImage image) {
+  public static void registerColors(HashMap<Integer, Integer> colorMap, BufferedImage image, boolean forceTransparentGreen) {
     final int Green = 0xff00ff00;
 
     if (image != null) {
@@ -1131,11 +1134,15 @@ public class PseudoBamDecoder extends BamDecoder {
           colorMap.put(key, count);
         }
       }
+      if (forceTransparentGreen && !colorMap.containsKey(Green)) {
+        colorMap.put(Green, 1);
+      }
     }
   }
 
   /** Unmaps all color values of the specified image. */
-  public static void unregisterColors(HashMap<Integer, Integer> colorMap, BufferedImage image) {
+  public static void unregisterColors(HashMap<Integer, Integer> colorMap, BufferedImage image,
+    boolean forcedTransparentGreen) {
     final int Green = 0xff00ff00;
 
     if (image != null) {
@@ -1187,6 +1194,9 @@ public class PseudoBamDecoder extends BamDecoder {
             }
           }
         }
+      }
+      if (forcedTransparentGreen && colorMap.get(Green) == 1) {
+        colorMap.remove(Green);
       }
     }
   }


### PR DESCRIPTION
While using Near Infinity's BAM Converter I noticed some artifacts in generated BAM V1s. I tracked the issue down to how NI builds the final palette — when NI imports images with no transparency it ends up using index 0 of the colormap for a normal color. According to the IESDP, the engine renders index 0 as transparent if no (0,255,0) color is defined the colormap, making the generated BAMs render incorrectly.

I'm unsure of the total scope of how NI handles BAMs, though I believe my edits fix the issue with no side effects. For non-paletted source images my changes force (0,255,0) to be a part of the colormap.