### PR TITLE
BAM Converter: medianCut() and getNearestColor() bugs

### DIFF
--- a/src/org/infinity/gui/converter/BamPaletteDialog.java
+++ b/src/org/infinity/gui/converter/BamPaletteDialog.java
@@ -315,6 +315,8 @@ class BamPaletteDialog extends JDialog
    * Calculates a new palette based on the currently registered colors and stores it in the PaletteDialog instance.
    */
   public void updateGeneratedPalette() {
+    final int Green = 0xff00ff00;
+
     if (isPaletteModified() && !lockedPalette) {
       if (colorMap.size() <= 256) {
         // checking whether all frames share the same palette
@@ -360,6 +362,12 @@ class BamPaletteDialog extends JDialog
         }
       } else {
         // reducing color count to max. 256
+
+        // medianCut() should not consider the special transparent green color, workaround to keep it preserved
+        Integer savedGreen = colorMap.get(Green);
+        if (savedGreen != null) {
+          colorMap.remove(Green);
+        }
         int[] pixels = new int[colorMap.size()];
         Iterator<Integer> iter = colorMap.keySet().iterator();
         int idx = 0;
@@ -367,7 +375,12 @@ class BamPaletteDialog extends JDialog
           pixels[idx] = iter.next();
           idx++;
         }
-        ColorConvert.medianCut(pixels, 256, palettes[TYPE_GENERATED], false);
+        final int desiredColors = savedGreen != null ? 255 : 256;
+        ColorConvert.medianCut(pixels, desiredColors, palettes[TYPE_GENERATED], false);
+        if (savedGreen != null) {
+          colorMap.put(Green, savedGreen);
+          palettes[TYPE_GENERATED][255] = Green;
+        }
       }
 
       // moving special "green" to the first index

--- a/src/org/infinity/gui/converter/ConvertToBam.java
+++ b/src/org/infinity/gui/converter/ConvertToBam.java
@@ -4153,7 +4153,7 @@ public class ConvertToBam extends ChildFrame implements ActionListener, Property
                 dstBuf[ofs] = colIdx;// (byte)ci;
               } else {
                 double weight = getUseAlpha() ? 1.0 : 0.0;
-                byte color = (byte) ColorConvert.getNearestColor(srcBuf[ofs], palette, weight, null);
+                byte color = (byte) ColorConvert.getNearestColor(srcBuf[ofs], palette, weight, null, true);
                 dstBuf[ofs] = color;// (byte)ci;
                 colorCache.put(c, color);
               }
@@ -4246,7 +4246,7 @@ public class ConvertToBam extends ChildFrame implements ActionListener, Property
               dstBuf[ofs] = colIdx;
             } else {
               double weight = getUseAlpha() ? 1.0 : 0.0;
-              byte color = (byte) ColorConvert.getNearestColor(srcBuf[ofs], palette, weight, null);
+              byte color = (byte) ColorConvert.getNearestColor(srcBuf[ofs], palette, weight, null, true);
               dstBuf[ofs] = color;// (byte)ci;
               colorCache.put(c, color);
             }


### PR DESCRIPTION
This pull request attempts to fix two bugs in the BAM Converter:

- When `medianCut()` is used to reduce the number of colors down to a palette of 256, the special green color could be altered. This results in incorrect transparency — whatever color ends up in the first palette index will render as transparent if the special green color is removed.
- `getNearestColor()` could select the transparent green color, which had the possibility of making colors adjacent to the transparent green incorrectly transparent.

Test case:

1. Add the attached images as frames.
2. Create a single cycle with all of the images assigned.
3. Observe the final frame of the cycle in the preview:
![image](https://user-images.githubusercontent.com/36863623/229327418-fdcf01c7-dc92-4686-9f8d-d06e49a8e49d.png)

With the fix:

![image](https://user-images.githubusercontent.com/36863623/229329804-4525f785-8a1c-4edc-9619-f6c887c7f766.png)

[images.zip](https://github.com/Argent77/NearInfinity/files/11131018/images.zip)