### PR TITLE
Fix advanced search not navigating the correct viewable

### DIFF
--- a/src/org/infinity/NearInfinity.java
+++ b/src/org/infinity/NearInfinity.java
@@ -888,7 +888,11 @@ public final class NearInfinity extends JFrame implements ActionListener, Viewab
   }
 
   public void showResourceEntry(ResourceEntry resourceEntry) {
-    tree.select(resourceEntry);
+    showResourceEntry(resourceEntry, null);
+  }
+
+  public void showResourceEntry(ResourceEntry resourceEntry, Operation doneOperation) {
+    tree.select(resourceEntry, doneOperation);
   }
 
   public void quit() {

--- a/src/org/infinity/check/BCSIDSChecker.java
+++ b/src/org/infinity/check/BCSIDSChecker.java
@@ -41,6 +41,7 @@ import org.infinity.resource.bcs.ScriptType;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.search.AbstractSearcher;
 import org.infinity.util.Misc;
+import org.infinity.util.Operation;
 
 /** Performs checking {@link BcsResource BCS} & {@code BS} resources. */
 public final class BCSIDSChecker extends AbstractSearcher implements Runnable, ActionListener, ListSelectionListener {
@@ -65,9 +66,13 @@ public final class BCSIDSChecker extends AbstractSearcher implements Runnable, A
       int row = table.getSelectedRow();
       if (row != -1) {
         ResourceEntry resourceEntry = (ResourceEntry) table.getValueAt(row, 0);
-        NearInfinity.getInstance().showResourceEntry(resourceEntry);
-        BcsResource bcsfile = (BcsResource) NearInfinity.getInstance().getViewable();
-        bcsfile.highlightText(((Integer) table.getValueAt(row, 2)), null);
+        NearInfinity.getInstance().showResourceEntry(resourceEntry, new Operation() {
+          @Override
+          public void perform() {
+            BcsResource bcsfile = (BcsResource) NearInfinity.getInstance().getViewable();
+            bcsfile.highlightText(((Integer) table.getValueAt(row, 2)), null);
+          }
+        });
       }
     } else if (event.getSource() == bopennew) {
       int row = table.getSelectedRow();

--- a/src/org/infinity/check/CreInvChecker.java
+++ b/src/org/infinity/check/CreInvChecker.java
@@ -44,6 +44,7 @@ import org.infinity.resource.cre.Item;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.search.AbstractSearcher;
 import org.infinity.util.Misc;
+import org.infinity.util.Operation;
 
 /** Performs checking {@link CreResource CRE} & {@code CHR} resources. */
 public final class CreInvChecker extends AbstractSearcher implements Runnable, ActionListener, ListSelectionListener {
@@ -68,9 +69,13 @@ public final class CreInvChecker extends AbstractSearcher implements Runnable, A
       int row = table.getSelectedRow();
       if (row != -1) {
         ResourceEntry resourceEntry = (ResourceEntry) table.getValueAt(row, 0);
-        NearInfinity.getInstance().showResourceEntry(resourceEntry);
-        ((AbstractStruct) NearInfinity.getInstance().getViewable()).getViewer()
-            .selectEntry(((Item) table.getValueAt(row, 2)).getName());
+        NearInfinity.getInstance().showResourceEntry(resourceEntry, new Operation() {
+          @Override
+          public void perform() {
+            ((AbstractStruct) NearInfinity.getInstance().getViewable()).getViewer()
+                .selectEntry(((Item) table.getValueAt(row, 2)).getName());
+          }
+        });
       }
     } else if (event.getSource() == bopennew) {
       int row = table.getSelectedRow();

--- a/src/org/infinity/check/DialogChecker.java
+++ b/src/org/infinity/check/DialogChecker.java
@@ -48,6 +48,7 @@ import org.infinity.resource.dlg.DlgResource;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.search.AbstractSearcher;
 import org.infinity.util.Misc;
+import org.infinity.util.Operation;
 
 /** Performs checking {@link DlgResource DLG} resources. */
 public final class DialogChecker extends AbstractSearcher
@@ -84,9 +85,14 @@ public final class DialogChecker extends AbstractSearcher
       int row = table.getSelectedRow();
       if (row != -1) {
         ResourceEntry resourceEntry = (ResourceEntry) table.getValueAt(row, 0);
-        NearInfinity.getInstance().showResourceEntry(resourceEntry);
-        ((AbstractStruct) NearInfinity.getInstance().getViewable()).getViewer()
-            .selectEntry((String) table.getValueAt(row, 1));
+        final SortableTable tableCapture = table;
+        NearInfinity.getInstance().showResourceEntry(resourceEntry, new Operation() {
+          @Override
+          public void perform() {
+            ((AbstractStruct) NearInfinity.getInstance().getViewable()).getViewer()
+                .selectEntry((String) tableCapture.getValueAt(row, 1));
+          }
+        });
       }
     } else if (event.getSource() == bopennew) {
       int row = table.getSelectedRow();

--- a/src/org/infinity/check/ScriptChecker.java
+++ b/src/org/infinity/check/ScriptChecker.java
@@ -43,6 +43,7 @@ import org.infinity.resource.bcs.ScriptMessage;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.search.AbstractSearcher;
 import org.infinity.util.Misc;
+import org.infinity.util.Operation;
 
 /** Performs checking {@link BcsResource BCS} & {@code BS} resources. */
 public final class ScriptChecker extends AbstractSearcher
@@ -76,9 +77,14 @@ public final class ScriptChecker extends AbstractSearcher
       int row = table.getSelectedRow();
       if (row != -1) {
         ResourceEntry resourceEntry = (ResourceEntry) table.getValueAt(row, 0);
-        NearInfinity.getInstance().showResourceEntry(resourceEntry);
-        ((BcsResource) NearInfinity.getInstance().getViewable()).highlightText(((Integer) table.getValueAt(row, 2)),
-            null);
+        final SortableTable tableCapture = table;
+        NearInfinity.getInstance().showResourceEntry(resourceEntry, new Operation() {
+          @Override
+          public void perform() {
+            ((BcsResource) NearInfinity.getInstance().getViewable())
+                .highlightText(((Integer) tableCapture.getValueAt(row, 2)), null);
+          }
+        });
       }
     } else if (event.getSource() == bopennew) {
       int row = table.getSelectedRow();

--- a/src/org/infinity/gui/ResourceTree.java
+++ b/src/org/infinity/gui/ResourceTree.java
@@ -68,6 +68,7 @@ import org.infinity.resource.key.ResourceEntry;
 import org.infinity.resource.key.ResourceTreeFolder;
 import org.infinity.resource.key.ResourceTreeModel;
 import org.infinity.util.IconCache;
+import org.infinity.util.Operation;
 import org.infinity.util.io.FileEx;
 import org.infinity.util.io.FileManager;
 import org.infinity.util.io.StreamUtils;
@@ -192,23 +193,37 @@ public final class ResourceTree extends JPanel implements TreeSelectionListener,
   }
 
   public void select(ResourceEntry entry, boolean forced) {
+    select(entry, forced, null);
+  }
+
+  public void select(ResourceEntry entry, Operation doneOperation) {
+    select(entry, false, doneOperation);
+  }
+
+  public void select(ResourceEntry entry, boolean forced, Operation doneOperation) {
     new SwingWorker<Void, Void>() {
       @Override
       protected Void doInBackground() throws Exception {
-          if (entry == null) {
-            tree.clearSelection();
-          } else if (forced || entry != shownResource) {
-            TreePath tp = ResourceFactory.getResourceTreeModel().getPathToNode(entry);
-            try {
-              expandListener.treeWillExpand(new TreeExpansionEvent(tree, tp));
-              tree.scrollPathToVisible(tp);
-              tree.addSelectionPath(tp);
-              tree.repaint();
-            } finally {
-              expandListener.treeExpanded(new TreeExpansionEvent(tree, tp));
-            }
+        if (entry == null) {
+          tree.clearSelection();
+        } else if (forced || entry != shownResource) {
+          TreePath tp = ResourceFactory.getResourceTreeModel().getPathToNode(entry);
+          try {
+            expandListener.treeWillExpand(new TreeExpansionEvent(tree, tp));
+            tree.scrollPathToVisible(tp);
+            tree.addSelectionPath(tp);
+            tree.repaint();
+          } finally {
+            expandListener.treeExpanded(new TreeExpansionEvent(tree, tp));
           }
+        }
         return null;
+      }
+      @Override
+      protected void done() {
+        if (doneOperation != null) {
+          doneOperation.perform();
+        }
       }
     }.execute();
   }

--- a/src/org/infinity/search/ReferenceHitFrame.java
+++ b/src/org/infinity/search/ReferenceHitFrame.java
@@ -43,6 +43,7 @@ import org.infinity.resource.dlg.DlgResource;
 import org.infinity.resource.key.FileResourceEntry;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.util.Misc;
+import org.infinity.util.Operation;
 
 public final class ReferenceHitFrame extends ChildFrame implements ActionListener, ListSelectionListener {
   private static final String QUERY_STRING = "string reference";
@@ -130,12 +131,16 @@ public final class ReferenceHitFrame extends ChildFrame implements ActionListene
             ((ViewFrame) parent).toFront();
           }
         } else {
-          NearInfinity.getInstance().showResourceEntry(entry);
-          Viewable viewable = NearInfinity.getInstance().getViewable();
-          showEntryInViewer(row, viewable);
-          if (viewable instanceof DlgResource) {
-            NearInfinity.getInstance().toFront();
-          }
+          NearInfinity.getInstance().showResourceEntry(entry, new Operation() {
+            @Override
+            public void perform() {
+              Viewable viewable = NearInfinity.getInstance().getViewable();
+              showEntryInViewer(row, viewable);
+              if (viewable instanceof DlgResource) {
+                NearInfinity.getInstance().toFront();
+              }
+            }
+          });
         }
       }
     } else if (event.getSource() == bopennew) {

--- a/src/org/infinity/search/TextHitFrame.java
+++ b/src/org/infinity/search/TextHitFrame.java
@@ -36,6 +36,7 @@ import org.infinity.resource.TextResource;
 import org.infinity.resource.Viewable;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.util.Misc;
+import org.infinity.util.Operation;
 
 final class TextHitFrame extends ChildFrame implements ActionListener, ListSelectionListener {
   private final Component parent;
@@ -119,11 +120,15 @@ final class TextHitFrame extends ChildFrame implements ActionListener, ListSelec
             ((TextResource) res).highlightText(((Integer) table.getValueAt(row, 2)), query);
           }
         } else {
-          NearInfinity.getInstance().showResourceEntry(entry);
-          Viewable viewable = NearInfinity.getInstance().getViewable();
-          if (viewable instanceof TextResource) {
-            ((TextResource) viewable).highlightText(((Integer) table.getValueAt(row, 2)), query);
-          }
+          NearInfinity.getInstance().showResourceEntry(entry, new Operation() {
+            @Override
+            public void perform() {
+              Viewable viewable = NearInfinity.getInstance().getViewable();
+              if (viewable instanceof TextResource) {
+                ((TextResource) viewable).highlightText(((Integer) table.getValueAt(row, 2)), query);
+              }
+            }
+          });
         }
       }
     } else if (event.getSource() == bopennew) {

--- a/src/org/infinity/search/advanced/AdvancedSearch.java
+++ b/src/org/infinity/search/advanced/AdvancedSearch.java
@@ -77,6 +77,7 @@ import org.infinity.resource.key.ResourceEntry;
 import org.infinity.search.ReferenceHitFrame;
 import org.infinity.util.Debugging;
 import org.infinity.util.Misc;
+import org.infinity.util.Operation;
 import org.infinity.util.SimpleListModel;
 
 public class AdvancedSearch extends ChildFrame implements Runnable {
@@ -819,12 +820,16 @@ public class AdvancedSearch extends ChildFrame implements Runnable {
         if (row != -1) {
           ResourceEntry entry = (ResourceEntry) listResults.getValueAt(row, 0);
           if (entry != null) {
-            NearInfinity.getInstance().showResourceEntry(entry);
-            Viewable viewable = NearInfinity.getInstance().getViewable();
-            showEntryInViewer(row, viewable);
-            if (viewable instanceof DlgResource) {
-              NearInfinity.getInstance().toFront();
-            }
+            NearInfinity.getInstance().showResourceEntry(entry, new Operation() {
+              @Override
+              public void perform() {
+                Viewable viewable = NearInfinity.getInstance().getViewable();
+                showEntryInViewer(row, viewable);
+                if (viewable instanceof DlgResource) {
+                  NearInfinity.getInstance().toFront();
+                }
+              }
+            });
           }
         }
       } else if (event.getSource() == bOpenNew) {


### PR DESCRIPTION
`showResourceEntry()` runs on a background thread. However, in several places Near Infinity calls `showResourceEntry()`, and immediately attempts to fetch the new viewable using `NearInfinity.getInstance().getViewable()`. This fetch often returns the "old" viewable, (as it was before the background thread got around to updating it).

A notable result of this bug is the advanced search sometimes navigating the wrong viewable. This can be tested by running an advanced search for an attribute that exists in a popup view, (such as a .SPL's ability header). The ability header of the currently selected .SPL will be erroneously displayed when opening a search result.

I have attempted to fix the issue by adding an optional callback that allows the relevant navigation code to execute _after_ the viewable has been updated. I updated every instance I could find of the `showResourceEntry()` -> `NearInfinity.getInstance().getViewable()` pattern.