### PR TITLE
Add arm64 Linux build artifacts

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -6,10 +6,7 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 1.8

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 1.8

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    branches: [ "master", "devel" ]
 
 permissions:
   contents: write
@@ -61,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macos-15-intel, macos-latest, ubuntu-latest ]
+        os: [ windows-latest, macos-15-intel, macos-latest, ubuntu-latest, ubuntu-24.04-arm ]
         java: [ '21' ]
     runs-on: ${{ matrix.os }}
     name: Create installer for ${{ matrix.os }}, JDK ${{ matrix.java }}
@@ -181,11 +180,18 @@ jobs:
           name: installer-macos-arm64
           path: NearInfinity-*.pkg
 
-      - name: Upload appimage artifact (linux)
-        if: startsWith(matrix.os, 'ubuntu-') && github.event_name == 'workflow_dispatch'
+      - name: Upload appimage artifact (linux-x86_64)
+        if: (matrix.os == 'ubuntu-latest') && github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v6
         with:
           name: installer-linux
+          path: NearInfinity-*.AppImage
+
+      - name: Upload appimage artifact (linux-aarch64)
+        if: (matrix.os == 'ubuntu-24.04-arm') && github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v6
+        with:
+          name: installer-linux-aarch64
           path: NearInfinity-*.AppImage
 
       # Uploading assets (release)
@@ -229,8 +235,18 @@ jobs:
           tag: ${{ github.ref || github.event.release.tag_name }}
           overwrite: true
 
-      - name: Upload appimage asset to release (linux)
-        if: startsWith(matrix.os, 'ubuntu-') && github.event_name == 'release'
+      - name: Upload appimage asset to release (linux-x86_64)
+        if: (matrix.os == 'ubuntu-latest') && github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file_glob: true
+          file: NearInfinity-*.AppImage
+          tag: ${{ github.ref || github.event.release.tag_name }}
+          overwrite: true
+
+      - name: Upload appimage asset to release (linux-aarch64)
+        if: (matrix.os == 'ubuntu-24.04-arm') && github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to add support for building and releasing on the `ubuntu-24.04-arm` (AArch64) platform.

**Other Workflow Adjustments:**

* Removed the invalid `branches` filter from the `workflow_dispatch` trigger in `.github/workflows/deploy.yml`, allowing manual workflow runs on any branch.