### PR TITLE
Improved dlg state parent search logic

### DIFF
--- a/src/org/infinity/resource/dlg/DlgTreeModel.java
+++ b/src/org/infinity/resource/dlg/DlgTreeModel.java
@@ -704,10 +704,12 @@ public class DlgTreeModel implements TreeModel, TreeNode, TableModelListener, Pr
     result.add(state);
     queue.add(state);
     do {
-      dlg.findUsages(queue.pop(), t -> dlg.findUsages(t, queue::add));
-      // Stop when no changes was made in result. If result changed, `queue`
-      // contains at least one value, so `pop()` on next iteration will not throw
-    } while (result.addAll(queue));
+      dlg.findUsages(queue.pop(), t -> dlg.findUsages(t, discoveredUpstreamState -> {
+        if (result.add(discoveredUpstreamState)) {
+          queue.add(discoveredUpstreamState);
+        }
+      }));
+    } while (!queue.isEmpty());
 
     return result;
   }


### PR DESCRIPTION
I do not recall exactly why I made this change initially, but apparently it fixes https://github.com/NearInfinityBrowser/NearInfinity/issues/148 - and logic is sound: instead of stopping on first "duplicate" upstream state we now keep going until all edges are traversed