### PR TITLE
Complete support for variable TIS tile dimensions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -2,7 +2,7 @@ name: Java CI with Apache Ant
 
 on:
   push:
-    branches: [ fork-nightly ]
+    branches: [ devel ]
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
           sed -i 's/debug="false"/debug="true"/' build.xml
           ant -noinput -buildfile build.xml
       - name: Upload artifact
-        if: ${{ github.repository == 'TheForgotten69/NearInfinity' }}
+        if: ${{ github.repository == 'Argent77/NearInfinity' }}
         uses: pyTooling/Actions/releaser@r2
         with:
           tag: nightly

--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -2,7 +2,7 @@ name: Java CI with Apache Ant
 
 on:
   push:
-    branches: [ devel ]
+    branches: [ fork-nightly ]
 
 jobs:
   build:
@@ -21,7 +21,7 @@ jobs:
           sed -i 's/debug="false"/debug="true"/' build.xml
           ant -noinput -buildfile build.xml
       - name: Upload artifact
-        if: ${{ github.repository == 'Argent77/NearInfinity' }}
+        if: ${{ github.repository == 'TheForgotten69/NearInfinity' }}
         uses: pyTooling/Actions/releaser@r2
         with:
           tag: nightly

--- a/src/org/infinity/gui/BIFFEditor.java
+++ b/src/org/infinity/gui/BIFFEditor.java
@@ -79,6 +79,13 @@ public final class BIFFEditor implements ActionListener, ListSelectionListener, 
     if (event.getSource() == bcancel) {
       editframe.close();
     } else if (event.getSource() == bsave) {
+      try {
+        validateBiffResources();
+      } catch (IllegalArgumentException e) {
+        JOptionPane.showMessageDialog(editframe, e.getMessage(), "Unsupported TIS tile dimension",
+            JOptionPane.ERROR_MESSAGE);
+        return;
+      }
       editframe.close();
       format = (AbstractBIFFReader.Type) cbformat.getSelectedItem();
       new Thread(this).start();
@@ -90,6 +97,18 @@ public final class BIFFEditor implements ActionListener, ListSelectionListener, 
       bsave.setEnabled(!biftable.isEmpty());
     } else if (event.getSource() == cbformat) {
       bsave.setEnabled(!biftable.isEmpty());
+    }
+  }
+
+  private void validateBiffResources() {
+    validateBiffResources(BIFFEditorTable.State.BIF, true);
+    validateBiffResources(BIFFEditorTable.State.NEW, false);
+    validateBiffResources(BIFFEditorTable.State.UPD, false);
+  }
+
+  private void validateBiffResources(BIFFEditorTable.State state, boolean ignoreOverride) {
+    for (final ResourceEntry entry : biftable.getValueList(state)) {
+      BIFFWriter.validateResource(entry, ignoreOverride);
     }
   }
 

--- a/src/org/infinity/gui/MassExporter.java
+++ b/src/org/infinity/gui/MassExporter.java
@@ -776,20 +776,23 @@ public final class MassExporter extends ChildFrame implements ActionListener, Li
       TisDecoder decoder = TisDecoder.loadTis(entry);
       if (decoder != null) {
         int tileCount = decoder.getTileCount();
+        int tileWidth = decoder.getTileWidth();
+        int tileHeight = decoder.getTileHeight();
         int columns = TisConvert.calcTilesetWidth(entry, true, 1);
         int rows = tileCount / columns;
         if ((tileCount % columns) != 0) {
           rows++;
         }
 
-        BufferedImage tile = ColorConvert.createCompatibleImage(64, 64, Transparency.BITMASK);
-        BufferedImage image = ColorConvert.createCompatibleImage(64 * columns, 64 * rows, Transparency.BITMASK);
+        BufferedImage tile = ColorConvert.createCompatibleImage(tileWidth, tileHeight, Transparency.BITMASK);
+        BufferedImage image = ColorConvert.createCompatibleImage(tileWidth * columns, tileHeight * rows,
+            Transparency.BITMASK);
         try {
           Graphics2D g = image.createGraphics();
           try {
             for (int i = 0; i < tileCount; i++) {
-              int x = 64 * (i % columns);
-              int y = 64 * (i / columns);
+              int x = tileWidth * (i % columns);
+              int y = tileHeight * (i / columns);
               decoder.getTile(i, tile);
               g.drawImage(tile, x, y, null);
             }

--- a/src/org/infinity/gui/converter/ConvertFileListPanel.java
+++ b/src/org/infinity/gui/converter/ConvertFileListPanel.java
@@ -41,7 +41,7 @@ import org.tinylog.Logger;
 
 /**
  * A panel that provides options for adding or removing files or folders of selected file types for conversion
- * operations. (Currently used by the BMP and PVRZ conversion dialogs.)
+ * operations.
  */
 public class ConvertFileListPanel extends AbstractConvertPanel implements ActionListener, ListSelectionListener {
   /** One or more files were added to the file list. */

--- a/src/org/infinity/gui/converter/ConvertOutputPanel.java
+++ b/src/org/infinity/gui/converter/ConvertOutputPanel.java
@@ -26,8 +26,7 @@ import org.infinity.util.io.FileEx;
 import org.infinity.util.io.FileManager;
 
 /**
- * A panel that handles output files and related options for conversion operations. (Currently used by the BMP and PVRZ
- * conversion dialogs.)
+ * A panel that handles output files and related options for conversion operations.
  */
 public class ConvertOutputPanel extends AbstractConvertPanel implements ActionListener, DocumentListener {
   /** Available file "Overwrite" modes. */

--- a/src/org/infinity/gui/converter/tis/ConvertToTis.java
+++ b/src/org/infinity/gui/converter/tis/ConvertToTis.java
@@ -39,6 +39,7 @@ import org.infinity.resource.Profile;
 import org.infinity.resource.graphics.ColorConvert;
 import org.infinity.resource.graphics.Compressor;
 import org.infinity.resource.graphics.DxtEncoder;
+import org.infinity.resource.graphics.TisDecoder;
 import org.infinity.util.BinPack2D;
 import org.infinity.util.DynamicArray;
 import org.infinity.util.IntegerHashMap;
@@ -91,6 +92,9 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
   public void panelUpdated(PanelUpdateEvent e) {
     if (e.getSource() == ioPanel) {
       handleIOPanel(e);
+    } else if (e.getSource() == tisOptionsPanel) {
+      updateInputStatus(false);
+      updateStatus();
     } else if (e.getSource() == buttonsPanel) {
       handleButtonPanel(e);
     }
@@ -141,15 +145,16 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
       if (inputFile != null) {
         final Dimension dim = ColorConvert.getImageDimension(inputFile);
         if (dim.width > 0 && dim.height > 0) {
-          final boolean isValid = (dim.width & 63) == 0 && (dim.height & 63) == 0;
+          final int tileDimension = tisOptionsPanel.getTileDimension();
+          final boolean isValid = (dim.width % tileDimension) == 0 && (dim.height % tileDimension) == 0;
           if (isValid) {
-            final int tileCount = (dim.width * dim.height) >>> 12;
+            final int tileCount = (dim.width / tileDimension) * (dim.height / tileDimension);
             tisOptionsPanel.setMaxTileCount(tileCount);
             tisOptionsPanel.setTileCount(tisOptionsPanel.getMaxTileCount());
             return;
           } else if (showFeedback) {
-            final String msg = "Image dimensions are not multiples of 64 pixels.\nImage: width=" + dim.width
-                + ", height=" + dim.height;
+            final String msg = "Image dimensions are not multiples of " + tileDimension
+                + " pixels.\nImage: width=" + dim.width + ", height=" + dim.height;
             JOptionPane.showMessageDialog(this, msg, "Error", JOptionPane.ERROR_MESSAGE);
           }
         }
@@ -213,6 +218,7 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
 
     // preparing tile count
     final int tileCount = tisOptionsPanel.getTileCount();
+    final int tileDimension = tisOptionsPanel.getTileDimension();
     if (tileCount < 1) {
       JOptionPane.showMessageDialog(this, "No tiles available for conversion.", "Error", JOptionPane.ERROR_MESSAGE);
       return;
@@ -220,7 +226,7 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
 
     // performing conversion task
     try {
-      final TisWorker worker = new TisWorker(this, inFile, outFile, tileCount, isLegacy, closeOnExit);
+      final TisWorker worker = new TisWorker(this, inFile, outFile, tileCount, tileDimension, isLegacy, closeOnExit);
       worker.execute();
     } catch (Exception e) {
       Logger.error(e);
@@ -238,13 +244,14 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
     setIconImage(Icons.ICON_APPLICATION_16.getIcon().getImage());
 
     final JLabel lInputNote =
-        new JLabel("Note: Width and height of the source image have to be a multiple of 64 pixels.");
+        new JLabel("Note: Width and height of the source image have to be a multiple of the selected tile size.");
 
     ioPanel = new ConvertIOPanel("Input & Output", currentPath, ColorConvert.GRAPHICS_FILTERS_DEFAULT,
         OUTPUT_FILE_FILTER, "TIS", ConvertIOPanel.DEFAULT_SHORT_PATH_GENERATOR, lInputNote);
     ioPanel.addPanelUpdateListener(this);
 
     tisOptionsPanel = new TisOptionsPanel();
+    tisOptionsPanel.addPanelUpdateListener(this);
     optionsPanel = new ConvertOptionsPanel("Options", tisOptionsPanel);
 
     buttonsPanel = new ConvertButtonsPanel();
@@ -289,6 +296,23 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
    */
   public static boolean convertV1(BufferedImage srcImage, Path outputFile, int tileCount, int minProgress,
       TisWorker worker) throws Exception {
+    return convertV1(srcImage, outputFile, tileCount, TisDecoder.DEFAULT_TILE_DIMENSION, minProgress, worker);
+  }
+
+  /**
+   * Converts an image to a palette-based TIS file using the specified square tile dimension.
+   *
+   * @param srcImage     Source {@link Image} to convert.
+   * @param outputFile   {@link Path} of the output TIS file.
+   * @param tileCount    Number of tiles to convert.
+   * @param tileDimension Width and height of a square tile, in pixels.
+   * @param minProgress  Start position for the progress monitor.
+   * @param worker       Optional {@link TisWorker} instance for tracking progress.
+   * @return {@code true} if the conversion finished successfully, {@code false} if the conversion was cancelled.
+   * @throws Exception thrown if an error occurs.
+   */
+  public static boolean convertV1(BufferedImage srcImage, Path outputFile, int tileCount, int tileDimension,
+      int minProgress, TisWorker worker) throws Exception {
     if (srcImage == null) {
       throw new NullPointerException("Source image is null.");
     }
@@ -296,37 +320,37 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
       throw new NullPointerException("Output file is null.");
     }
 
-    if ((srcImage.getWidth() & 63) != 0 || (srcImage.getHeight() & 63) != 0) {
-      throw new IllegalArgumentException("Source image dimensions must be a multiple of 64.\nImage: width="
-          + srcImage.getWidth() + ", height=" + srcImage.getHeight());
-    }
+    validateTileDimension(tileDimension);
+    validateImageDimensions(srcImage.getWidth(), srcImage.getHeight(), tileDimension);
 
     if (tileCount < 1) {
       throw new IllegalArgumentException("Tile count cannot be 0 or negative.");
     }
-    final int maxTileCount = (srcImage.getWidth() * srcImage.getHeight()) >>> 12;
+    final int maxTileCount = (srcImage.getWidth() / tileDimension) * (srcImage.getHeight() / tileDimension);
     if (tileCount > maxTileCount) {
       final String msg = "Tile count exceeds max. number of tiles (" + tileCount + " > " + maxTileCount + ')';
       throw new IllegalArgumentException(msg);
     }
 
     final int[] srcBuffer = ((DataBufferInt)srcImage.getRaster().getDataBuffer()).getData();
-    final byte[] dstBuffer = new byte[24 + tileCount * 5120]; // header + tiles
+    final int tileDataSize = Math.multiplyExact(tileDimension, tileDimension);
+    final int tileRecordSize = Math.addExact(1024, tileDataSize);
+    final byte[] dstBuffer = new byte[Math.addExact(24, Math.multiplyExact(tileCount, tileRecordSize))];
     int dstOfs = 0; // current start offset for write operations
 
     // writing header data
     System.arraycopy("TIS V1  ".getBytes(), 0, dstBuffer, 0, 8);
     DynamicArray.putInt(dstBuffer, 8, tileCount);
-    DynamicArray.putInt(dstBuffer, 12, 0x1400);
+    DynamicArray.putInt(dstBuffer, 12, tileRecordSize);
     DynamicArray.putInt(dstBuffer, 16, 0x18);
-    DynamicArray.putInt(dstBuffer, 20, 0x40);
+    DynamicArray.putInt(dstBuffer, 20, tileDimension);
     dstOfs += 24;
 
-    final int[] srcBlock = new int[64 * 64]; // temp. storage for a single tile
+    final int[] srcBlock = new int[tileDataSize]; // temp. storage for a single tile
     final int[] palette = new int[255]; // temp. storage for generated palette
     final byte[] tilePalette = new byte[1024]; // final palette for output
-    final byte[] tileData = new byte[64 * 64]; // final tile data for output
-    int tw = srcImage.getWidth() / 64; // tiles per row
+    final byte[] tileData = new byte[tileDataSize]; // final tile data for output
+    int tw = srcImage.getWidth() / tileDimension; // tiles per row
 
     final int updateBlock = (tileCount > 300) ? 100 : 10;
     final IntegerHashMap<Byte> colorCache = new IntegerHashMap<>(2048); // caching RGBColor -> index
@@ -347,9 +371,10 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
       colorCache.clear();
 
       // initializing source tile
-      int inOfs = ty * 64 * srcImage.getWidth() + tx * 64;
-      for (int i = 0, outOfs = 0; i < 64; i++, inOfs += srcImage.getWidth(), outOfs += 64) {
-        System.arraycopy(srcBuffer, inOfs, srcBlock, outOfs, 64);
+      int inOfs = ty * tileDimension * srcImage.getWidth() + tx * tileDimension;
+      for (int i = 0, outOfs = 0; i < tileDimension;
+          i++, inOfs += srcImage.getWidth(), outOfs += tileDimension) {
+        System.arraycopy(srcBuffer, inOfs, srcBlock, outOfs, tileDimension);
       }
 
       // reducing colors
@@ -388,8 +413,8 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
       // writing final palette and pixel data to output
       System.arraycopy(tilePalette, 0, dstBuffer, dstOfs, 1024);
       dstOfs += 1024;
-      System.arraycopy(tileData, 0, dstBuffer, dstOfs, 4096);
-      dstOfs += 4096;
+      System.arraycopy(tileData, 0, dstBuffer, dstOfs, tileDataSize);
+      dstOfs += tileDataSize;
     }
 
     // writing TIS file to disk
@@ -417,6 +442,24 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
    */
   public static boolean convertV2(BufferedImage srcImage, Path outputFile, int tileCount, int minProgress,
       TisWorker worker) throws Exception {
+    return convertV2(srcImage, outputFile, tileCount, TisDecoder.DEFAULT_TILE_DIMENSION, minProgress, worker);
+  }
+
+  /**
+   * Converts an image to a PVRZ-based TIS file using the specified square tile dimension.
+   *
+   * @param srcImage     Source {@link Image} to convert.
+   * @param outputFile   {@link Path} of the output TIS file. PVRZ files are placed into the same directory as the
+   *                       output TIS file.
+   * @param tileCount    Number of tiles to convert.
+   * @param tileDimension Width and height of a square tile, in pixels.
+   * @param minProgress  Start position for the progress monitor.
+   * @param worker       Optional {@link TisWorker} instance for tracking progress.
+   * @return {@code true} if the conversion finished successfully, {@code false} if the conversion was cancelled.
+   * @throws Exception thrown if an error occurs.
+   */
+  public static boolean convertV2(BufferedImage srcImage, Path outputFile, int tileCount, int tileDimension,
+      int minProgress, TisWorker worker) throws Exception {
     if (srcImage == null) {
       throw new NullPointerException("Source image is null.");
     }
@@ -424,15 +467,13 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
       throw new NullPointerException("Output file is null.");
     }
 
-    if ((srcImage.getWidth() & 63) != 0 || (srcImage.getHeight() & 63) != 0) {
-      throw new IllegalArgumentException("Source image dimensions must be a multiple of 64.\nImage: width="
-          + srcImage.getWidth() + ", height=" + srcImage.getHeight());
-    }
+    validateTileDimension(tileDimension);
+    validateImageDimensions(srcImage.getWidth(), srcImage.getHeight(), tileDimension);
 
     if (tileCount < 1) {
       throw new IllegalArgumentException("Tile count cannot be 0 or negative.");
     }
-    final int maxTileCount = (srcImage.getWidth() * srcImage.getHeight()) >>> 12;
+    final int maxTileCount = (srcImage.getWidth() / tileDimension) * (srcImage.getHeight() / tileDimension);
     if (tileCount > maxTileCount) {
       final String msg = "Tile count exceeds max. number of tiles (" + tileCount + " > " + maxTileCount + ')';
       throw new IllegalArgumentException(msg);
@@ -449,11 +490,11 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
     DynamicArray.putInt(dstBuffer, 8, tileCount);
     DynamicArray.putInt(dstBuffer, 12, 0x0c);
     DynamicArray.putInt(dstBuffer, 16, 0x18);
-    DynamicArray.putInt(dstBuffer, 20, 0x40);
+    DynamicArray.putInt(dstBuffer, 20, tileDimension);
     dstOfs += 24;
 
     // processing tiles
-    generatePageInfo(srcImage.getWidth(), srcImage.getHeight(), tileCount, pageList, entryList);
+    generatePageInfo(srcImage.getWidth(), srcImage.getHeight(), tileCount, tileDimension, pageList, entryList);
 
     // writing TIS entries
     entryList.sort(TileEntry.COMPARE_BY_INDEX);
@@ -473,7 +514,8 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
     }
 
     // generating PVRZ files
-    return createPvrzPages(outputFile, srcImage, pageList, DxtEncoder.DxtType.DXT1, entryList, minProgress, worker);
+    return createPvrzPages(outputFile, srcImage, pageList, DxtEncoder.DxtType.DXT1, entryList, tileDimension,
+        minProgress, worker);
   }
 
   /**
@@ -489,10 +531,26 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
    */
   public static int generatePageInfo(int imageWidth, int imageHeight, int tileCount, List<BinPack2D> pageList,
       List<TileEntry> entryList) throws Exception {
-    if ((imageWidth & 63) != 0 || (imageHeight & 63) != 0) {
-      throw new IllegalArgumentException("Source image dimensions must be a multiple of 64.\nImage: width="
-          + imageWidth + ", height=" + imageHeight);
-    }
+    return generatePageInfo(imageWidth, imageHeight, tileCount, TisDecoder.DEFAULT_TILE_DIMENSION, pageList,
+        entryList);
+  }
+
+  /**
+   * Generates PVRZ page data using the specified square tile dimension.
+   *
+   * @param imageWidth   Source image width.
+   * @param imageHeight  Source image height.
+   * @param tileCount    Number of tiles to convert.
+   * @param tileDimension Width and height of a square tile, in pixels.
+   * @param pageList     Empty list where {@link BinPack2D} structures are stored by this method.
+   * @param entryList    Empty list where {@link TileEntry} structures are stored by this method.
+   * @return Number of generated PVRZ page entries.
+   * @throws Exception if an error occurs.
+   */
+  public static int generatePageInfo(int imageWidth, int imageHeight, int tileCount, int tileDimension,
+      List<BinPack2D> pageList, List<TileEntry> entryList) throws Exception {
+    validateTileDimension(tileDimension);
+    validateImageDimensions(imageWidth, imageHeight, tileDimension);
 
     if (pageList == null) {
       pageList = new ArrayList<>();
@@ -504,8 +562,7 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
 
     final BinPack2D.HeuristicRules binPackRule = BinPack2D.HeuristicRules.BOTTOM_LEFT_RULE;
     final int pageDim = 1024;
-    final int tileDim = 64;
-    final int tilesPerDim = pageDim / tileDim;
+    final int tilesPerDim = pageDim / tileDimension;
     final int pw = imageWidth / pageDim + (((imageWidth % pageDim) != 0) ? 1 : 0);
     final int ph = imageHeight / pageDim + (((imageHeight % pageDim) != 0) ? 1 : 0);
 
@@ -515,7 +572,7 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
         final int w = Math.min(pageDim, imageWidth - x);
         final int h = Math.min(pageDim, imageHeight - y);
 
-        final Dimension space = new Dimension(w / tileDim, h / tileDim);
+        final Dimension space = new Dimension(w / tileDimension, h / tileDimension);
         int pageIdx = -1;
         Rectangle rectMatch = null;
         for (int i = 0; i < pageList.size(); i++) {
@@ -536,13 +593,13 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
         }
 
         // registering tile entries
-        int tileIdx = (y * imageWidth) / (tileDim * tileDim) + x / tileDim;
-        for (int ty = 0; ty < space.height; ty++, tileIdx += imageWidth / tileDim) {
+        int tileIdx = (y * imageWidth) / (tileDimension * tileDimension) + x / tileDimension;
+        for (int ty = 0; ty < space.height; ty++, tileIdx += imageWidth / tileDimension) {
           for (int tx = 0; tx < space.width; tx++) {
             // marking page index as incomplete
             if (tileIdx + tx < tileCount) {
-              TileEntry entry = new TileEntry(tileIdx + tx, pageIdx, (rectMatch.x + tx) * tileDim,
-                  (rectMatch.y + ty) * tileDim);
+              TileEntry entry = new TileEntry(tileIdx + tx, pageIdx, (rectMatch.x + tx) * tileDimension,
+                  (rectMatch.y + ty) * tileDimension);
               entryList.add(entry);
             }
           }
@@ -567,7 +624,8 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
    * @throws Exception thrown if an error occurs.
    */
   private static boolean createPvrzPages(Path tisFile, BufferedImage srcImage, List<BinPack2D> pageList,
-      DxtEncoder.DxtType dxtType, List<TileEntry> entryList, int minProgress, TisWorker worker) throws Exception {
+      DxtEncoder.DxtType dxtType, List<TileEntry> entryList, int tileDimension, int minProgress, TisWorker worker)
+      throws Exception {
     final int dxtCode = (dxtType == DxtEncoder.DxtType.DXT5) ? 11 : 7;
     final byte[] output = new byte[DxtEncoder.calcImageSize(1024, 1024, dxtType)];
 
@@ -586,20 +644,22 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
       packer.shrinkBin(true);
 
       // generating texture image
-      int w = packer.getBinWidth() * 64;
-      int h = packer.getBinHeight() * 64;
+      int w = packer.getBinWidth() * tileDimension;
+      int h = packer.getBinHeight() * tileDimension;
       final BufferedImage texture = ColorConvert.createCompatibleImage(w, h, true);
       final Graphics2D g = texture.createGraphics();
       g.setComposite(AlphaComposite.Src);
       g.setColor(ColorConvert.TRANSPARENT_COLOR);
       g.fillRect(0, 0, texture.getWidth(), texture.getHeight());
-      int tw = srcImage.getWidth() / 64;
+      int tw = srcImage.getWidth() / tileDimension;
       for (final TileEntry entry : entryList) {
         if (entry.page == pageIdx) {
-          int sx = (entry.tileIndex % tw) * 64, sy = (entry.tileIndex / tw) * 64;
+          int sx = (entry.tileIndex % tw) * tileDimension;
+          int sy = (entry.tileIndex / tw) * tileDimension;
           int dx = entry.x, dy = entry.y;
-          g.fillRect(dx, dy, 64, 64);
-          g.drawImage(srcImage, dx, dy, dx + 64, dy + 64, sx, sy, sx + 64, sy + 64, null);
+          g.fillRect(dx, dy, tileDimension, tileDimension);
+          g.drawImage(srcImage, dx, dy, dx + tileDimension, dy + tileDimension, sx, sy, sx + tileDimension,
+              sy + tileDimension, null);
         }
       }
       g.dispose();
@@ -629,6 +689,21 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
     }
 
     return true;
+  }
+
+  private static void validateTileDimension(int tileDimension) {
+    if (tileDimension < 4 || tileDimension > TisDecoder.MAX_TILE_DIMENSION
+        || (tileDimension & (tileDimension - 1)) != 0) {
+      throw new IllegalArgumentException("Tile dimension must be a power of two between 4 and "
+          + TisDecoder.MAX_TILE_DIMENSION + " pixels: " + tileDimension);
+    }
+  }
+
+  private static void validateImageDimensions(int imageWidth, int imageHeight, int tileDimension) {
+    if ((imageWidth % tileDimension) != 0 || (imageHeight % tileDimension) != 0) {
+      throw new IllegalArgumentException("Source image dimensions must be a multiple of " + tileDimension
+          + ".\nImage: width=" + imageWidth + ", height=" + imageHeight);
+    }
   }
 
   /**
@@ -682,7 +757,7 @@ public class ConvertToTis extends ChildFrame implements PanelUpdateListener {
    * @return A valid TIS file {@link Path}.
    * @throws NullPointerException if {@code tisFile} is {@code null}.
    */
-  private static Path createValidTisPath(Path tisFile, boolean isLegacy) {
+  static Path createValidTisPath(Path tisFile, boolean isLegacy) {
     if (tisFile == null) {
       throw new NullPointerException("tisFile is null");
     }

--- a/src/org/infinity/gui/converter/tis/ConvertToTisBatch.java
+++ b/src/org/infinity/gui/converter/tis/ConvertToTisBatch.java
@@ -1,0 +1,158 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.gui.converter.tis;
+
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import org.infinity.gui.ChildFrame;
+import org.infinity.gui.ViewerUtil;
+import org.infinity.gui.converter.ConvertButtonsPanel;
+import org.infinity.gui.converter.ConvertFileListPanel;
+import org.infinity.gui.converter.ConvertOutputPanel;
+import org.infinity.gui.converter.ConvertOutputPanel.Overwrite;
+import org.infinity.gui.converter.PanelUpdateEvent;
+import org.infinity.gui.converter.PanelUpdateListener;
+import org.infinity.icon.Icons;
+import org.infinity.resource.Profile;
+import org.infinity.util.io.FileManager;
+import org.tinylog.Logger;
+
+/** Dialog for converting multiple PNG files to palette-based or PVRZ-based TIS files. */
+public class ConvertToTisBatch extends ChildFrame implements PanelUpdateListener {
+  private static final List<FileNameExtensionFilter> INPUT_FILTERS = Arrays.asList(
+      new FileNameExtensionFilter("PNG files (*.png)", "png"));
+
+  private static Path currentPath = Profile.getGameRoot();
+
+  private ConvertFileListPanel fileListPanel;
+  private ConvertOutputPanel outputPanel;
+  private TisBatchOptionsPanel optionsPanel;
+  private ConvertButtonsPanel buttonsPanel;
+
+  public ConvertToTisBatch() {
+    super("Batch convert to TIS", true);
+    init();
+  }
+
+  /** Resets dialog content and optionally hides the dialog window. */
+  public void hideWindow(boolean hide) {
+    reset();
+    if (hide) {
+      setVisible(false);
+    }
+  }
+
+  @Override
+  protected boolean windowClosing(boolean forced) throws Exception {
+    currentPath = outputPanel.getCurrentDirectory();
+    reset();
+    return super.windowClosing(forced);
+  }
+
+  @Override
+  public void panelUpdated(PanelUpdateEvent e) {
+    if (e.getSource() == buttonsPanel) {
+      if (e.getReason() == ConvertButtonsPanel.REASON_CONVERT) {
+        convert();
+      } else if (e.getReason() == ConvertButtonsPanel.REASON_CANCEL) {
+        hideWindow(true);
+      }
+    }
+    updateStatus();
+  }
+
+  private void reset() {
+    fileListPanel.reset();
+    outputPanel.reset();
+    optionsPanel.reset();
+  }
+
+  private void updateStatus() {
+    final boolean hasInput = fileListPanel.getFileCount() > 0;
+    final boolean hasOutput = !outputPanel.getOutputFolder().isEmpty();
+    buttonsPanel.setConvertButtonEnabled(hasInput && hasOutput);
+  }
+
+  private void convert() {
+    final List<Path> inputFiles = fileListPanel.getFiles();
+    if (inputFiles.isEmpty()) {
+      JOptionPane.showMessageDialog(this, "No input files defined.", "Error", JOptionPane.ERROR_MESSAGE);
+      return;
+    }
+
+    Path outputDir = null;
+    try {
+      outputDir = FileManager.resolve(outputPanel.getOutputFolder());
+    } catch (Exception e) {
+      Logger.debug(e);
+    }
+    if (outputDir == null) {
+      JOptionPane.showMessageDialog(this, "Invalid output directory specified.", "Error",
+          JOptionPane.ERROR_MESSAGE);
+      return;
+    }
+
+    final Overwrite overwrite = outputPanel.getOverwriteMode();
+    final int tileDimension = optionsPanel.getTileDimension();
+    final boolean legacy = optionsPanel.isLegacyVersionSelected();
+    final boolean closeOnExit = buttonsPanel.isCloseOnExit();
+
+    try {
+      new TisBatchWorker(this, inputFiles, outputDir, overwrite, tileDimension, legacy, closeOnExit).execute();
+    } catch (Exception e) {
+      Logger.error(e);
+      JOptionPane.showMessageDialog(this, e.getMessage(), "Error", JOptionPane.ERROR_MESSAGE);
+    }
+  }
+
+  private void init() {
+    setIconImage(Icons.ICON_APPLICATION_16.getIcon().getImage());
+
+    fileListPanel = new ConvertFileListPanel("Input", currentPath, INPUT_FILTERS);
+    fileListPanel.addPanelUpdateListener(this);
+
+    optionsPanel = new TisBatchOptionsPanel();
+
+    outputPanel = new ConvertOutputPanel("Output", currentPath, optionsPanel);
+    outputPanel.addPanelUpdateListener(this);
+
+    buttonsPanel = new ConvertButtonsPanel();
+    buttonsPanel.addPanelUpdateListener(this);
+
+    final GridBagConstraints c = new GridBagConstraints();
+    final JPanel panelMain = new JPanel(new GridBagLayout());
+    ViewerUtil.setGBC(c, 0, 0, 1, 1, 1.0, 1.0, GridBagConstraints.FIRST_LINE_START, GridBagConstraints.BOTH,
+        new Insets(0, 0, 0, 0), 0, 0);
+    panelMain.add(fileListPanel, c);
+    ViewerUtil.setGBC(c, 0, 1, 1, 1, 1.0, 0.0, GridBagConstraints.FIRST_LINE_START,
+        GridBagConstraints.HORIZONTAL, new Insets(8, 0, 0, 0), 0, 0);
+    panelMain.add(outputPanel, c);
+    ViewerUtil.setGBC(c, 0, 2, 1, 1, 1.0, 0.0, GridBagConstraints.FIRST_LINE_START,
+        GridBagConstraints.HORIZONTAL, new Insets(8, 0, 0, 0), 0, 0);
+    panelMain.add(buttonsPanel, c);
+
+    setLayout(new GridBagLayout());
+    ViewerUtil.setGBC(c, 0, 0, 1, 1, 1.0, 1.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+        new Insets(8, 8, 8, 8), 0, 0);
+    add(panelMain, c);
+
+    updateStatus();
+    setPreferredSize(new Dimension(getPreferredSize().width + 50, getPreferredSize().height + 50));
+    setMinimumSize(getPreferredSize());
+    pack();
+    setLocationRelativeTo(getParent());
+    setVisible(true);
+  }
+}

--- a/src/org/infinity/gui/converter/tis/TisBatchOptionsPanel.java
+++ b/src/org/infinity/gui/converter/tis/TisBatchOptionsPanel.java
@@ -1,0 +1,65 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.gui.converter.tis;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+
+import org.infinity.gui.ViewerUtil;
+import org.infinity.gui.converter.AbstractConvertPanel;
+import org.infinity.resource.graphics.TisDecoder;
+
+/** Options shared by all files processed by the batch TIS converter. */
+class TisBatchOptionsPanel extends AbstractConvertPanel {
+  private final JComboBox<Integer> cbTileDimension =
+      new JComboBox<>(new Integer[] { 64, 128, 256, TisDecoder.MAX_TILE_DIMENSION });
+  private final JComboBox<String> cbTisVersion = new JComboBox<>(new String[] { "Legacy", "PVRZ-based" });
+
+  public TisBatchOptionsPanel() {
+    super(new GridBagLayout());
+    init();
+  }
+
+  /** Returns the selected width and height of a square tile, in pixels. */
+  public int getTileDimension() {
+    return (Integer)cbTileDimension.getSelectedItem();
+  }
+
+  /** Returns whether the legacy palette-based TIS version is selected. */
+  public boolean isLegacyVersionSelected() {
+    return cbTisVersion.getSelectedIndex() == 0;
+  }
+
+  /** Resets all options to their defaults. */
+  public void reset() {
+    cbTileDimension.setSelectedItem(TisDecoder.DEFAULT_TILE_DIMENSION);
+    cbTisVersion.setSelectedIndex(0);
+  }
+
+  private void init() {
+    final JLabel lTileDimension = new JLabel("Tile dimensions:");
+    final JLabel lTisVersion = new JLabel("Tileset version:");
+    final GridBagConstraints c = new GridBagConstraints();
+
+    ViewerUtil.setGBC(c, 0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(0, 0, 0, 0), 0, 0);
+    add(lTileDimension, c);
+    ViewerUtil.setGBC(c, 1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(0, 8, 0, 0), 0, 0);
+    add(cbTileDimension, c);
+    ViewerUtil.setGBC(c, 0, 1, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(8, 0, 0, 0), 0, 0);
+    add(lTisVersion, c);
+    ViewerUtil.setGBC(c, 1, 1, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(8, 8, 0, 0), 0, 0);
+    add(cbTisVersion, c);
+
+    reset();
+  }
+}

--- a/src/org/infinity/gui/converter/tis/TisBatchOptionsPanel.java
+++ b/src/org/infinity/gui/converter/tis/TisBatchOptionsPanel.java
@@ -8,8 +8,10 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 
+import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 
 import org.infinity.gui.ViewerUtil;
 import org.infinity.gui.converter.AbstractConvertPanel;
@@ -20,6 +22,8 @@ class TisBatchOptionsPanel extends AbstractConvertPanel {
   private final JComboBox<Integer> cbTileDimension =
       new JComboBox<>(new Integer[] { 64, 128, 256, TisDecoder.MAX_TILE_DIMENSION });
   private final JComboBox<String> cbTisVersion = new JComboBox<>(new String[] { "Legacy", "PVRZ-based" });
+  private final JButton bTileDimensionHelp = TisOptionsPanel.createHelpButton("About tile dimensions...");
+  private final JButton bTisVersionHelp = TisOptionsPanel.createHelpButton("About tileset versions...");
 
   public TisBatchOptionsPanel() {
     super(new GridBagLayout());
@@ -46,19 +50,29 @@ class TisBatchOptionsPanel extends AbstractConvertPanel {
     final JLabel lTileDimension = new JLabel("Tile dimensions:");
     final JLabel lTisVersion = new JLabel("Tileset version:");
     final GridBagConstraints c = new GridBagConstraints();
+    bTileDimensionHelp.addActionListener(e -> JOptionPane.showMessageDialog(ViewerUtil.getWindowAncestor(this),
+        TisOptionsPanel.createTileDimensionHelpMessage(), "About tile dimensions", JOptionPane.INFORMATION_MESSAGE));
+    bTisVersionHelp.addActionListener(e -> JOptionPane.showMessageDialog(ViewerUtil.getWindowAncestor(this),
+        TisOptionsPanel.TIS_VERSION_HELP, "About tileset versions", JOptionPane.INFORMATION_MESSAGE));
 
     ViewerUtil.setGBC(c, 0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
         new Insets(0, 0, 0, 0), 0, 0);
     add(lTileDimension, c);
-    ViewerUtil.setGBC(c, 1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+    ViewerUtil.setGBC(c, 1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
         new Insets(0, 8, 0, 0), 0, 0);
     add(cbTileDimension, c);
+    ViewerUtil.setGBC(c, 2, 0, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(0, 8, 0, 0), 0, 0);
+    add(bTileDimensionHelp, c);
     ViewerUtil.setGBC(c, 0, 1, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
         new Insets(8, 0, 0, 0), 0, 0);
     add(lTisVersion, c);
-    ViewerUtil.setGBC(c, 1, 1, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+    ViewerUtil.setGBC(c, 1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
         new Insets(8, 8, 0, 0), 0, 0);
     add(cbTisVersion, c);
+    ViewerUtil.setGBC(c, 2, 1, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(8, 8, 0, 0), 0, 0);
+    add(bTisVersionHelp, c);
 
     reset();
   }

--- a/src/org/infinity/gui/converter/tis/TisBatchWorker.java
+++ b/src/org/infinity/gui/converter/tis/TisBatchWorker.java
@@ -1,0 +1,173 @@
+// Near Infinity - An Infinity Engine Browser and Editor
+// Copyright (C) 2001 Jon Olav Hauglid
+// See LICENSE.txt for license information
+
+package org.infinity.gui.converter.tis;
+
+import java.awt.image.BufferedImage;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.imageio.ImageIO;
+import javax.swing.JOptionPane;
+
+import org.infinity.gui.converter.AbstractConvertWorker;
+import org.infinity.gui.converter.ConvertOutputPanel.Overwrite;
+import org.infinity.gui.converter.WorkerResult;
+import org.infinity.resource.graphics.ColorConvert;
+import org.infinity.util.io.FileEx;
+import org.infinity.util.io.StreamUtils;
+import org.tinylog.Logger;
+
+/** Worker for converting multiple PNG files to TIS files. */
+class TisBatchWorker extends AbstractConvertWorker<WorkerResult> {
+  private final ConvertToTisBatch parent;
+  private final List<Path> inputFiles;
+  private final Path outputDir;
+  private final Overwrite overwrite;
+  private final int tileDimension;
+  private final boolean legacy;
+  private final boolean closeOnExit;
+
+  public TisBatchWorker(ConvertToTisBatch parent, List<Path> inputFiles, Path outputDir, Overwrite overwrite,
+      int tileDimension, boolean legacy, boolean closeOnExit) {
+    super(parent, true, true, 0, inputFiles.size(), "Converting to TIS...", 250, 1000);
+    this.parent = Objects.requireNonNull(parent);
+    this.inputFiles = Objects.requireNonNull(inputFiles);
+    this.outputDir = Objects.requireNonNull(outputDir);
+    this.overwrite = Objects.requireNonNull(overwrite);
+    this.tileDimension = tileDimension;
+    this.legacy = legacy;
+    this.closeOnExit = closeOnExit;
+    setProgressNote("Preparing");
+  }
+
+  @Override
+  protected WorkerResult doInBackground() throws Exception {
+    int failed = 0;
+    int skipped = 0;
+    final List<String> errors = new ArrayList<>();
+    final Set<Path> outputFiles = new HashSet<>();
+    final Set<String> pvrzBaseNames = new HashSet<>();
+
+    for (int i = 0, count = inputFiles.size(); i < count; i++) {
+      if (isProgressCancelled()) {
+        cancel(false);
+        return null;
+      }
+
+      setProgressNote("File " + (i + 1) + " / " + count);
+      advanceProgressTo(i);
+
+      try {
+        final Path inputFile = inputFiles.get(i);
+        final Path outputFile = outputDir.resolve(
+            StreamUtils.replaceFileExtension(inputFile.getFileName().toString(), "TIS"));
+        final Path validOutputFile = ConvertToTis.createValidTisPath(outputFile, legacy);
+        if (!outputFile.getFileName().toString().equalsIgnoreCase(validOutputFile.getFileName().toString())) {
+          throw new IllegalArgumentException("Invalid TIS filename for the selected format: "
+              + outputFile.getFileName());
+        }
+        if (!outputFiles.add(outputFile.toAbsolutePath().normalize())) {
+          throw new IllegalArgumentException("Multiple input files resolve to the same output file: "
+              + outputFile.getFileName());
+        }
+        if (!legacy) {
+          final String fileName = outputFile.getFileName().toString();
+          final int extensionPos = fileName.lastIndexOf('.');
+          final String resourceName = (extensionPos >= 0) ? fileName.substring(0, extensionPos) : fileName;
+          final String pvrzBaseName = (resourceName.charAt(0) + resourceName.substring(2)).toUpperCase(Locale.ENGLISH);
+          if (!pvrzBaseNames.add(pvrzBaseName)) {
+            throw new IllegalArgumentException("Multiple TIS files resolve to the same PVRZ page names: "
+                + outputFile.getFileName());
+          }
+        }
+
+        if (FileEx.create(outputFile).exists()) {
+          switch (overwrite) {
+            case ASK:
+            {
+              final String msg = "File " + outputFile + " already exists. Overwrite?";
+              final int result = JOptionPane.showConfirmDialog(parent, msg, "Overwrite",
+                  JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+              if (result == JOptionPane.NO_OPTION) {
+                skipped++;
+                continue;
+              } else if (result == JOptionPane.CANCEL_OPTION) {
+                cancel(false);
+                return null;
+              }
+              break;
+            }
+            case SKIP:
+              skipped++;
+              continue;
+            default:
+          }
+        }
+
+        final BufferedImage image = ColorConvert.toBufferedImage(ImageIO.read(inputFile.toFile()), true);
+        if (image == null) {
+          throw new Exception("Unable to load source image: " + inputFile);
+        }
+        if ((image.getWidth() % tileDimension) != 0 || (image.getHeight() % tileDimension) != 0) {
+          throw new IllegalArgumentException("Image dimensions are not multiples of " + tileDimension + ": "
+              + inputFile.getFileName());
+        }
+
+        final int tileCount = (image.getWidth() / tileDimension) * (image.getHeight() / tileDimension);
+        if (legacy) {
+          ConvertToTis.convertV1(image, outputFile, tileCount, tileDimension, 0, null);
+        } else {
+          ConvertToTis.convertV2(image, outputFile, tileCount, tileDimension, 0, null);
+        }
+      } catch (Exception e) {
+        failed++;
+        errors.add(inputFiles.get(i).getFileName() + ": "
+            + ((e.getMessage() != null) ? e.getMessage() : e.getClass().getSimpleName()));
+        Logger.debug(e);
+      }
+    }
+
+    final StringBuilder message = new StringBuilder();
+    if (failed == 0) {
+      message.append("Conversion finished successfully.");
+    } else {
+      message.append("Conversion finished with ").append(failed).append(" error(s).");
+    }
+    if (skipped > 0) {
+      message.append('\n').append(skipped).append(" file(s) skipped.");
+    }
+    if (!errors.isEmpty()) {
+      message.append("\n\nErrors:");
+      for (int i = 0, count = Math.min(5, errors.size()); i < count; i++) {
+        message.append("\n- ").append(errors.get(i));
+      }
+      if (errors.size() > 5) {
+        message.append("\n- ... and ").append(errors.size() - 5).append(" more");
+      }
+    }
+    return new WorkerResult(failed == 0, message.toString());
+  }
+
+  @Override
+  protected void onCompleted(WorkerResult result) {
+    final String message = (result != null) ? result.getMessage() : "Conversion finished successfully.";
+    final int messageType = result != null && result.isSuccess()
+        ? JOptionPane.INFORMATION_MESSAGE : JOptionPane.ERROR_MESSAGE;
+    JOptionPane.showMessageDialog(parent, message, "Batch TIS conversion", messageType);
+    parent.hideWindow(closeOnExit);
+  }
+
+  @Override
+  protected void onCancelled() {
+    JOptionPane.showMessageDialog(parent, "Conversion cancelled by the user.", "Batch TIS conversion",
+        JOptionPane.INFORMATION_MESSAGE);
+    parent.hideWindow(closeOnExit);
+  }
+}

--- a/src/org/infinity/gui/converter/tis/TisOptionsPanel.java
+++ b/src/org/infinity/gui/converter/tis/TisOptionsPanel.java
@@ -27,6 +27,8 @@ import javax.swing.event.DocumentListener;
 
 import org.infinity.gui.ViewerUtil;
 import org.infinity.gui.converter.AbstractConvertPanel;
+import org.infinity.gui.converter.PanelUpdateEvent;
+import org.infinity.resource.graphics.TisDecoder;
 import org.infinity.util.Misc;
 
 /** Subpanel with TIS-specific options. */
@@ -57,7 +59,7 @@ class TisOptionsPanel extends AbstractConvertPanel
   private static final String TIS_VERSION_HELP =
         '"' + TisVersion.LEGACY.toString() + "\" is the original tileset format supported by all available\n"
       + "Infinity Engine games. Graphics data is stored in the TIS file directly.\n"
-      + "Each tile (64x64 pixel block) is limited to a 256 color table.\n"
+      + "Each tile is limited to a 256 color table.\n"
       + "Note: This format may produce visual artifacts in Enhanced Edition games.\n\n"
       + '"' + TisVersion.PVRZ.toString() + "\" uses a new tileset format that is only compatible with the\n"
       + "Enhanced Editions. Graphics data is stored separately in PVRZ files and is\n"
@@ -65,6 +67,7 @@ class TisOptionsPanel extends AbstractConvertPanel
 
   private JSlider slTileCount;
   private JTextField tfTileCount;
+  private JComboBox<Integer> cbTileDimension;
   private JComboBox<TisVersion> cbTisVersion;
   private JButton bTisVersionHelp;
 
@@ -108,6 +111,16 @@ class TisOptionsPanel extends AbstractConvertPanel
     slTileCount.setValue(newValue);
   }
 
+  /** Returns the selected width and height of a square tile, in pixels. */
+  public int getTileDimension() {
+    return (Integer)cbTileDimension.getSelectedItem();
+  }
+
+  /** Selects the width and height of a square tile, in pixels. */
+  public void setTileDimension(int tileDimension) {
+    cbTileDimension.setSelectedItem(tileDimension);
+  }
+
   /** Returns whether the legacy (palette-based) TIS version is selected. */
   public boolean isLegacyVersionSelected() {
     return cbTisVersion.getSelectedIndex() == 0;
@@ -123,6 +136,7 @@ class TisOptionsPanel extends AbstractConvertPanel
 
   /** Resets the panel to its initial state. */
   public void reset() {
+    setTileDimension(TisDecoder.DEFAULT_TILE_DIMENSION);
     setLegacyVersionSelected(true);
   }
 
@@ -133,6 +147,8 @@ class TisOptionsPanel extends AbstractConvertPanel
     if (e.getSource() == bTisVersionHelp) {
       JOptionPane.showMessageDialog(ViewerUtil.getWindowAncestor(this), TIS_VERSION_HELP, "About tileset versions",
           JOptionPane.INFORMATION_MESSAGE);
+    } else if (e.getSource() == cbTileDimension) {
+      firePanelUpdate(PanelUpdateEvent.REASON_UNKNOWN);
     }
   }
 
@@ -221,6 +237,11 @@ class TisOptionsPanel extends AbstractConvertPanel
     tfTileCount.getDocument().addDocumentListener(this);
     tfTileCount.addFocusListener(this);
 
+    final JLabel lTileDimension = new JLabel("Tile dimensions:");
+    cbTileDimension = new JComboBox<>(new Integer[] { 64, 128, 256, TisDecoder.MAX_TILE_DIMENSION });
+    cbTileDimension.setSelectedItem(TisDecoder.DEFAULT_TILE_DIMENSION);
+    cbTileDimension.addActionListener(this);
+
     final JLabel lTisVersion = new JLabel("Tileset version:");
     cbTisVersion = new JComboBox<>(TisVersion.values());
     cbTisVersion.setSelectedIndex(0);
@@ -245,6 +266,15 @@ class TisOptionsPanel extends AbstractConvertPanel
         new Insets(0, 8, 0, 0), 0, 0);
     panelTileCount.add(tfTileCount, c);
 
+    // Subpanel for tile dimensions
+    final JPanel panelTileDimension = new JPanel(new GridBagLayout());
+    ViewerUtil.setGBC(c, 0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(0, 0, 0, 0), 0, 0);
+    panelTileDimension.add(lTileDimension, c);
+    ViewerUtil.setGBC(c, 1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(0, 8, 0, 0), 0, 0);
+    panelTileDimension.add(cbTileDimension, c);
+
     // Subpanel for tileset version
     final JPanel panelTisVersion = new JPanel(new GridBagLayout());
     ViewerUtil.setGBC(c, 0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
@@ -262,6 +292,9 @@ class TisOptionsPanel extends AbstractConvertPanel
         new Insets(0, 0, 0, 0), 0, 0);
     add(panelTileCount, c);
     ViewerUtil.setGBC(c, 0, 1, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.HORIZONTAL,
+        new Insets(8, 0, 0, 0), 0, 0);
+    add(panelTileDimension, c);
+    ViewerUtil.setGBC(c, 0, 2, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.HORIZONTAL,
         new Insets(8, 0, 0, 0), 0, 0);
     add(panelTisVersion, c);
 

--- a/src/org/infinity/gui/converter/tis/TisOptionsPanel.java
+++ b/src/org/infinity/gui/converter/tis/TisOptionsPanel.java
@@ -56,7 +56,14 @@ class TisOptionsPanel extends AbstractConvertPanel
     }
   }
 
-  private static final String TIS_VERSION_HELP =
+  static final String TILE_DIMENSION_HELP =
+        TisDecoder.DEFAULT_TILE_DIMENSION + "x" + TisDecoder.DEFAULT_TILE_DIMENSION
+      + " pixels is the standard tile dimension supported by unmodified game executables.\n\n"
+      + "Nonstandard tile dimensions require:";
+  private static final String TILE_DIMENSION_HELP_URL =
+      "https://github.com/TheForgotten69/InfinityEngine-Enhancer";
+
+  static final String TIS_VERSION_HELP =
         '"' + TisVersion.LEGACY.toString() + "\" is the original tileset format supported by all available\n"
       + "Infinity Engine games. Graphics data is stored in the TIS file directly.\n"
       + "Each tile is limited to a 256 color table.\n"
@@ -68,6 +75,7 @@ class TisOptionsPanel extends AbstractConvertPanel
   private JSlider slTileCount;
   private JTextField tfTileCount;
   private JComboBox<Integer> cbTileDimension;
+  private JButton bTileDimensionHelp;
   private JComboBox<TisVersion> cbTisVersion;
   private JButton bTisVersionHelp;
 
@@ -144,7 +152,10 @@ class TisOptionsPanel extends AbstractConvertPanel
 
   @Override
   public void actionPerformed(ActionEvent e) {
-    if (e.getSource() == bTisVersionHelp) {
+    if (e.getSource() == bTileDimensionHelp) {
+      JOptionPane.showMessageDialog(ViewerUtil.getWindowAncestor(this), createTileDimensionHelpMessage(),
+          "About tile dimensions", JOptionPane.INFORMATION_MESSAGE);
+    } else if (e.getSource() == bTisVersionHelp) {
       JOptionPane.showMessageDialog(ViewerUtil.getWindowAncestor(this), TIS_VERSION_HELP, "About tileset versions",
           JOptionPane.INFORMATION_MESSAGE);
     } else if (e.getSource() == cbTileDimension) {
@@ -241,16 +252,14 @@ class TisOptionsPanel extends AbstractConvertPanel
     cbTileDimension = new JComboBox<>(new Integer[] { 64, 128, 256, TisDecoder.MAX_TILE_DIMENSION });
     cbTileDimension.setSelectedItem(TisDecoder.DEFAULT_TILE_DIMENSION);
     cbTileDimension.addActionListener(this);
+    bTileDimensionHelp = createHelpButton("About tile dimensions...");
+    bTileDimensionHelp.addActionListener(this);
 
     final JLabel lTisVersion = new JLabel("Tileset version:");
     cbTisVersion = new JComboBox<>(TisVersion.values());
     cbTisVersion.setSelectedIndex(0);
-    bTisVersionHelp = new JButton("?");
-    bTisVersionHelp.setToolTipText("About tileset versions...");
+    bTisVersionHelp = createHelpButton("About tileset versions...");
     bTisVersionHelp.addActionListener(this);
-    final Insets insets = bTisVersionHelp.getMargin();
-    insets.left = insets.right = 4;
-    bTisVersionHelp.setMargin(insets);
 
     final GridBagConstraints c = new GridBagConstraints();
 
@@ -271,9 +280,12 @@ class TisOptionsPanel extends AbstractConvertPanel
     ViewerUtil.setGBC(c, 0, 0, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
         new Insets(0, 0, 0, 0), 0, 0);
     panelTileDimension.add(lTileDimension, c);
-    ViewerUtil.setGBC(c, 1, 0, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+    ViewerUtil.setGBC(c, 1, 0, 1, 1, 0.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
         new Insets(0, 8, 0, 0), 0, 0);
     panelTileDimension.add(cbTileDimension, c);
+    ViewerUtil.setGBC(c, 2, 0, 1, 1, 1.0, 0.0, GridBagConstraints.LINE_START, GridBagConstraints.NONE,
+        new Insets(0, 8, 0, 0), 0, 0);
+    panelTileDimension.add(bTileDimensionHelp, c);
 
     // Subpanel for tileset version
     final JPanel panelTisVersion = new JPanel(new GridBagLayout());
@@ -314,5 +326,21 @@ class TisOptionsPanel extends AbstractConvertPanel
       }
     }
     return retVal;
+  }
+
+  static JButton createHelpButton(String toolTipText) {
+    final JButton button = new JButton("?");
+    button.setToolTipText(toolTipText);
+    final Insets insets = button.getMargin();
+    insets.left = insets.right = 4;
+    button.setMargin(insets);
+    return button;
+  }
+
+  static Object[] createTileDimensionHelpMessage() {
+    return new Object[] {
+        TILE_DIMENSION_HELP,
+        ViewerUtil.createUrlLabel("Infinity Engine Enhancer", TILE_DIMENSION_HELP_URL),
+    };
   }
 }

--- a/src/org/infinity/gui/converter/tis/TisWorker.java
+++ b/src/org/infinity/gui/converter/tis/TisWorker.java
@@ -23,10 +23,11 @@ class TisWorker extends AbstractConvertWorker<WorkerResult> {
   private final Path inputFile;
   private final Path outputFile;
   private final int tileCount;
+  private final int tileDimension;
   private final boolean isLegacy;
   private final boolean closeOnExit;
 
-  public TisWorker(ConvertToTis parent, Path inFile, Path outFile, int tileCount, boolean isLegacy,
+  public TisWorker(ConvertToTis parent, Path inFile, Path outFile, int tileCount, int tileDimension, boolean isLegacy,
       boolean closeOnExit) {
     super(parent, true, true, 0, 5, "Converting to TIS...", 250, 1000);
     if (tileCount < 1) {
@@ -36,6 +37,7 @@ class TisWorker extends AbstractConvertWorker<WorkerResult> {
     this.inputFile = Objects.requireNonNull(inFile);
     this.outputFile = Objects.requireNonNull(outFile);
     this.tileCount = tileCount;
+    this.tileDimension = tileDimension;
     this.isLegacy = isLegacy;
     this.closeOnExit = closeOnExit;
     setProgressNote("Preparing tileset");
@@ -60,9 +62,9 @@ class TisWorker extends AbstractConvertWorker<WorkerResult> {
     String message = null;
     try {
       if (isLegacy) {
-        success = ConvertToTis.convertV1(srcImage, outputFile, tileCount, 1, this);
+        success = ConvertToTis.convertV1(srcImage, outputFile, tileCount, tileDimension, 1, this);
       } else {
-        success = ConvertToTis.convertV2(srcImage, outputFile, tileCount, 1, this);
+        success = ConvertToTis.convertV2(srcImage, outputFile, tileCount, tileDimension, 1, this);
       }
 
       if (success) {
@@ -91,7 +93,8 @@ class TisWorker extends AbstractConvertWorker<WorkerResult> {
         return false;
       }
       try {
-        final int pageCount = ConvertToTis.generatePageInfo(dim.width, dim.height, tileCount, null, null);
+        final int pageCount = ConvertToTis.generatePageInfo(dim.width, dim.height, tileCount, tileDimension, null,
+            null);
         setMaxProgress(pageCount + 1);  // include preparation stage
       } catch (Exception e) {
         Logger.error(e);

--- a/src/org/infinity/gui/menu/ToolsMenu.java
+++ b/src/org/infinity/gui/menu/ToolsMenu.java
@@ -45,6 +45,7 @@ import org.infinity.gui.converter.bmp.ConvertToBmp;
 import org.infinity.gui.converter.mos.ConvertToMos;
 import org.infinity.gui.converter.pvrz.ConvertToPvrz;
 import org.infinity.gui.converter.tis.ConvertToTis;
+import org.infinity.gui.converter.tis.ConvertToTisBatch;
 import org.infinity.icon.Icons;
 import org.infinity.resource.Profile;
 import org.infinity.resource.ResourceFactory;
@@ -90,6 +91,7 @@ public class ToolsMenu extends JMenu implements BrowserSubMenu, ActionListener {
   private final JMenuItem toolConvImageToBmp;
   private final JMenuItem toolConvImageToMos;
   private final JMenuItem toolConvImageToTis;
+  private final JMenuItem toolConvImagesToTis;
   private final JMenuItem toolConvImageToPvrz;
 
   private final JCheckBoxMenuItem toolConsole;
@@ -228,6 +230,10 @@ public class ToolsMenu extends JMenu implements BrowserSubMenu, ActionListener {
     toolConvImageToTis = BrowserMenuBar.makeMenuItem("Image to TIS...", KeyEvent.VK_T,
         Icons.ICON_APPLICATION_16.getIcon(), -1, this);
     convertMenu.add(toolConvImageToTis);
+
+    toolConvImagesToTis = BrowserMenuBar.makeMenuItem("Batch images to TIS...", KeyEvent.VK_I,
+        Icons.ICON_APPLICATION_16.getIcon(), -1, this);
+    convertMenu.add(toolConvImagesToTis);
     // *** End Convert submenu ***
 
     addSeparator();
@@ -397,6 +403,8 @@ public class ToolsMenu extends JMenu implements BrowserSubMenu, ActionListener {
       ChildFrame.show(ConvertToPvrz.class, ConvertToPvrz::new);
     } else if (event.getSource() == toolConvImageToTis) {
       ChildFrame.show(ConvertToTis.class, ConvertToTis::new);
+    } else if (event.getSource() == toolConvImagesToTis) {
+      ChildFrame.show(ConvertToTisBatch.class, ConvertToTisBatch::new);
     } else if (event.getSource() == toolConvImageToMos) {
       ChildFrame.show(ConvertToMos.class, ConvertToMos::new);
     } else if (event.getSource() == toolConvImageToBmp) {

--- a/src/org/infinity/resource/are/viewer/TilesetRenderer.java
+++ b/src/org/infinity/resource/are/viewer/TilesetRenderer.java
@@ -1180,13 +1180,31 @@ public class TilesetRenderer extends RenderCanvas {
           try {
             TisDecoder decoder = TisDecoder.loadTis(tisEntry);
             isTisPalette = decoder.getType() == TisDecoder.Type.PALETTE;
-            BufferedImage tileImage = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+            final int tileWidth = decoder.getTileWidth();
+            final int tileHeight = decoder.getTileHeight();
+            BufferedImage tileImage = new BufferedImage(tileWidth, tileHeight, BufferedImage.TYPE_INT_ARGB);
+            BufferedImage scaledTileImage = null;
+            Graphics2D scaledTileGraphics = null;
+            if (tileWidth != 64 || tileHeight != 64) {
+              scaledTileImage = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+              scaledTileGraphics = scaledTileImage.createGraphics();
+              scaledTileGraphics.setComposite(AlphaComposite.Src);
+            }
             for (int i = 0, tCount = decoder.getTileCount(); i < tCount; i++) {
               decoder.getTile(i, tileImage);
-              int[] srcData = ((DataBufferInt) tileImage.getRaster().getDataBuffer()).getData();
+              BufferedImage sourceImage = tileImage;
+              if (scaledTileGraphics != null) {
+                scaledTileGraphics.drawImage(tileImage, 0, 0, 64, 64, null);
+                sourceImage = scaledTileImage;
+              }
+              int[] srcData = ((DataBufferInt) sourceImage.getRaster().getDataBuffer()).getData();
               int[] dstData = new int[64 * 64];
               System.arraycopy(srcData, 0, dstData, 0, 64 * 64);
               listTileData.add(dstData);
+            }
+            if (scaledTileGraphics != null) {
+              scaledTileGraphics.dispose();
+              scaledTileImage.flush();
             }
             tileImage.flush();
             tileImage = null;

--- a/src/org/infinity/resource/graphics/TisConvert.java
+++ b/src/org/infinity/resource/graphics/TisConvert.java
@@ -98,10 +98,11 @@ public class TisConvert {
      */
     static Couple<BufferedImage, BufferedImage> init(int tileIndex, BufferedImage tileImage, TisDecoder decoder,
         TileInfo tileInfo) throws Exception {
-      final int tileSize = 64;
+      final int tileWidth = decoder.getTileWidth();
+      final int tileHeight = decoder.getTileHeight();
       final boolean isPrimary = (tileInfo.getPrimaryTileFrame(tileIndex) >= 0);
 
-      final BufferedImage tileImage2 = ColorConvert.createCompatibleImage(tileSize, tileSize, true);
+      final BufferedImage tileImage2 = ColorConvert.createCompatibleImage(tileWidth, tileHeight, true);
       final Couple<BufferedImage, BufferedImage> retVal = new Couple<>(null, null);
       if (isPrimary) {
         decoder.getTile(tileInfo.tileSecondary, tileImage2);
@@ -552,6 +553,8 @@ public class TisConvert {
 
     final List<Image> tiles = config.getTileList();
     final TisV2Decoder decoder = (TisV2Decoder) config.getDecoder();
+    final int tileWidth = decoder.getTileWidth();
+    final int tileHeight = decoder.getTileHeight();
     final WedInfo wedInfo = config.getWedInfo();
     final OverlayConversion conversionMode = config.getOverlayConversion();
 
@@ -567,17 +570,17 @@ public class TisConvert {
       System.arraycopy("TIS V1  ".getBytes(), 0, header, 0, 8);
       // TODO: use different tile count source when implementing overlay conversion modes that change tileset layout
       DynamicArray.putInt(header, 0x08, decoder.getTileCount());
-      DynamicArray.putInt(header, 0x0c, 0x1400);
+      DynamicArray.putInt(header, 0x0c, 0x400 + tileWidth * tileHeight);
       DynamicArray.putInt(header, 0x10, 0x18);
-      DynamicArray.putInt(header, 0x14, 0x40);
+      DynamicArray.putInt(header, 0x14, tileWidth);
       bos.write(header);
 
       // processing TIS data
       final int[] palette = new int[255];
       final byte[] tilePalette = new byte[256 * 4];
-      final byte[] tileData = new byte[Config.TILE_SIZE * Config.TILE_SIZE];
+      final byte[] tileData = new byte[tileWidth * tileHeight];
       BufferedImage tileImageOut =
-          ColorConvert.createCompatibleImage(Config.TILE_SIZE, Config.TILE_SIZE, Transparency.BITMASK);
+          ColorConvert.createCompatibleImage(tileWidth, tileHeight, Transparency.BITMASK);
       final IntegerHashMap<Byte> colorCache = new IntegerHashMap<>(1800); // caching RGB -> index
       for (int tileIdx = 0, tileCount = decoder.getTileCount(); tileIdx < tileCount; tileIdx++) {
         colorCache.clear();
@@ -701,6 +704,7 @@ public class TisConvert {
 
     try {
       final TisV1Decoder decoder = (TisV1Decoder) config.getDecoder();
+      final int tileSize = decoder.getTileWidth();
       final WedInfo wedInfo = config.getWedInfo();
       final int width = wedInfo.getWidth();
       final int height = wedInfo.getHeight();
@@ -718,7 +722,7 @@ public class TisConvert {
       final BitSet markedTiles = new BitSet(decoder.getTileCount());
 
       // processing primary tiles
-      final TileMap tmBase = new TileMap(wedInfo);
+      final TileMap tmBase = new TileMap(wedInfo, tileSize);
       final int numTiles = decoder.getTileCount();
       for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
@@ -757,7 +761,7 @@ public class TisConvert {
           for (int j = 1; j < ti.tilesPrimary.length; j++) {
             if (!markedTiles.get(ti.tilesPrimary[j])) {
               if (!detectBlack || !isTileBlack(decoder, ti.tilesPrimary[j])) {
-                final TileMap tm = new TileMap(wedInfo);
+                final TileMap tm = new TileMap(wedInfo, tileSize);
                 tm.setTile(x, y, ti.tilesPrimary[j], TileMapItem.FLAG_ALL);
                 markedTiles.set(ti.tilesPrimary[j]);
                 final List<TileMap> list = createTileRegions(config, tm);
@@ -772,7 +776,7 @@ public class TisConvert {
       for (int i = 0, count = wedInfo.getDoorCount(); i < count; i++) {
         if (wedInfo.getDoorTileCount(i) > 0) {
           // adding door tiles
-          final TileMap tm = new TileMap(wedInfo);
+          final TileMap tm = new TileMap(wedInfo, tileSize);
           final int[] indices = wedInfo.getDoorTileIndices(i);
           for (final int idx : indices) {
             if (idx < 0 || idx >= wedInfo.getWidth() * wedInfo.getHeight()) {
@@ -797,7 +801,7 @@ public class TisConvert {
       }
 
       // processing secondary tiles not covered by previous operations
-      final TileMap mapAll = new TileMap(wedInfo);
+      final TileMap mapAll = new TileMap(wedInfo, tileSize);
       for (int i = 0, count = wedInfo.getTileCount(); i < count; i++) {
         final TileInfo ti = wedInfo.getTile(i);
         if (ti.tileSecondary >= 0 && !markedTiles.get(ti.tileSecondary)) {
@@ -957,7 +961,7 @@ public class TisConvert {
     decoder2.getTilePalette(tileIndex, pal, true);
 
     // loading raw tile data
-    final byte[] tileData = new byte[Config.TILE_SIZE * Config.TILE_SIZE];
+    final byte[] tileData = new byte[decoder.getTileWidth() * decoder.getTileHeight()];
     decoder2.getRawTileData(tileIndex, tileData);
 
     // checking whether tile consists of solid color
@@ -1003,6 +1007,7 @@ public class TisConvert {
     final int height = wedInfo.getHeight();
     final int textureSize = config.getTextureSize();
     final int borderSize = config.getBorderSize();
+    final int tileSize = config.getTileSize();
     final Set<Point> locations = new HashSet<>(tileMap.getAllTilePositions(false));
     final Rectangle tileBounds = tileMap.getTileBounds(true);
 
@@ -1010,27 +1015,27 @@ public class TisConvert {
     int y0 = 0;
     final Rectangle regionBounds = new Rectangle(tileBounds.x + x0, tileBounds.y + y0, 0, 0);
     while (x0 < tileBounds.width && y0 < tileBounds.height) {
-      final TileMap tm = new TileMap(wedInfo);
+      final TileMap tm = new TileMap(wedInfo, tileSize);
 
       // calculating horizontal tile map size
       int borderLeft = (tileBounds.x + x0 > 0) ? borderSize : 0;
-      int numTilesX = Math.min(textureSize / Config.TILE_SIZE, tileBounds.width - x0);
-      while (numTilesX * Config.TILE_SIZE + borderLeft > textureSize) {
+      int numTilesX = Math.min(textureSize / tileSize, tileBounds.width - x0);
+      while (numTilesX * tileSize + borderLeft > textureSize) {
         numTilesX--;
       }
       int borderRight = (tileBounds.x + x0 + numTilesX < width) ? borderSize : 0;
-      while (numTilesX * Config.TILE_SIZE + borderLeft + borderRight > textureSize) {
+      while (numTilesX * tileSize + borderLeft + borderRight > textureSize) {
         numTilesX--;
       }
 
       // calculating vertical tile map size
       int borderTop = (tileBounds.y + y0 > 0) ? borderSize : 0;
-      int numTilesY = Math.min(textureSize / Config.TILE_SIZE, tileBounds.height - y0);
-      while (numTilesY * Config.TILE_SIZE + borderTop > textureSize) {
+      int numTilesY = Math.min(textureSize / tileSize, tileBounds.height - y0);
+      while (numTilesY * tileSize + borderTop > textureSize) {
         numTilesY--;
       }
       int borderBottom = (tileBounds.y + y0 + numTilesY < height) ? borderSize : 0;
-      while (numTilesY * Config.TILE_SIZE + borderTop + borderBottom > textureSize) {
+      while (numTilesY * tileSize + borderTop + borderBottom > textureSize) {
         numTilesY--;
       }
 
@@ -1235,7 +1240,8 @@ public class TisConvert {
     Objects.requireNonNull(config, "Configuration instance is null");
     Objects.requireNonNull(pvrzFile, "PVRZ file path is null");
     Objects.requireNonNull(tileMaps, "Tile map list is null");
-    if (width < 64 || height < 64 || width > 1024 || height > 1024) {
+    if (width < config.getTileSize() || height < config.getTileSize() ||
+        width > config.getMaxTextureSize() || height > config.getMaxTextureSize()) {
       throw new IllegalArgumentException("Unsupported texture size (width=" + width + ", height=" + height + ")");
     }
     if (tileMaps.isEmpty()) {
@@ -1310,7 +1316,8 @@ public class TisConvert {
       conversionMode = OverlayConversion.NONE;
     }
 
-    BufferedImage tileImg = ColorConvert.createCompatibleImage(Config.TILE_SIZE, Config.TILE_SIZE, true);
+    final int tileSize = config.getTileSize();
+    BufferedImage tileImg = ColorConvert.createCompatibleImage(tileSize, tileSize, true);
     final List<Point> locations = tileMap.getAllTilePositions(false);
     for (final Point p : locations) {
       final TileMapItem tmi = tileMap.getTile(p);
@@ -1339,32 +1346,32 @@ public class TisConvert {
           final int x1, y1, x2, y2;
           switch (flag) {
             case TileMapItem.FLAG_TOP:          // rendering only top rows of pixels
-              x1 = 0; y1 = 0; x2 = Config.TILE_SIZE; y2 = borderSize;
+              x1 = 0; y1 = 0; x2 = tileSize; y2 = borderSize;
               break;
             case TileMapItem.FLAG_BOTTOM:       // rendering only bottom rows of pixels
-              x1 = 0; y1 = Config.TILE_SIZE - borderSize; x2 = Config.TILE_SIZE; y2 = Config.TILE_SIZE;
+              x1 = 0; y1 = tileSize - borderSize; x2 = tileSize; y2 = tileSize;
               break;
             case TileMapItem.FLAG_LEFT:         // rendering only left columns of pixels
-              x1 = 0; y1 = 0; x2 = borderSize; y2 = Config.TILE_SIZE;
+              x1 = 0; y1 = 0; x2 = borderSize; y2 = tileSize;
               break;
             case TileMapItem.FLAG_RIGHT:        // rendering only right columns of pixels
-              x1 = Config.TILE_SIZE - borderSize; y1 = 0; x2 = Config.TILE_SIZE; y2 = Config.TILE_SIZE;
+              x1 = tileSize - borderSize; y1 = 0; x2 = tileSize; y2 = tileSize;
               break;
             case TileMapItem.FLAG_TOP_LEFT:     // rendering only top left rectangle of pixels
               x1 = 0; y1 = 0; x2 = borderSize; y2 = borderSize;
               break;
             case TileMapItem.FLAG_TOP_RIGHT:    // rendering only top right rectangle of pixels
-              x1 = Config.TILE_SIZE - borderSize; y1 = 0; x2 = Config.TILE_SIZE; y2 = borderSize;
+              x1 = tileSize - borderSize; y1 = 0; x2 = tileSize; y2 = borderSize;
               break;
             case TileMapItem.FLAG_BOTTOM_LEFT:  // rendering only bottom left rectangle of pixels
-              x1 = 0; y1 = Config.TILE_SIZE - borderSize; x2 = borderSize; y2 = Config.TILE_SIZE;
+              x1 = 0; y1 = tileSize - borderSize; x2 = borderSize; y2 = tileSize;
               break;
             case TileMapItem.FLAG_BOTTOM_RIGHT: // rendering only bottom right rectangle of pixels
-              x1 = Config.TILE_SIZE - borderSize; y1 = Config.TILE_SIZE - borderSize;
-              x2 = Config.TILE_SIZE; y2 = Config.TILE_SIZE;
+              x1 = tileSize - borderSize; y1 = tileSize - borderSize;
+              x2 = tileSize; y2 = tileSize;
               break;
             case TileMapItem.FLAG_ALL:          // rendering full tile
-              x1 = 0; y1 = 0; x2 = Config.TILE_SIZE; y2 = Config.TILE_SIZE;
+              x1 = 0; y1 = 0; x2 = tileSize; y2 = tileSize;
               break;
             default:                            // just added for completeness
               x1 = y1 = x2 = y2 = 0;
@@ -1397,7 +1404,7 @@ public class TisConvert {
       DynamicArray.putInt(header, 0x08, config.getDecoder().getTileCount());
       DynamicArray.putInt(header, 0x0c, 0x0c);
       DynamicArray.putInt(header, 0x10, 0x18);
-      DynamicArray.putInt(header, 0x14, 0x40);
+      DynamicArray.putInt(header, 0x14, config.getTileSize());
       bos.write(header);
 
       final TileEntry defEntry = new TileEntry(-1, -1, 0, 0);
@@ -1488,7 +1495,7 @@ public class TisConvert {
     // performing overlay conversion
     if (isPrimary) {
       // removing all pixels on primary tile that are transparent on secondary tile
-      for (int idx = 0, size = Config.TILE_SIZE * Config.TILE_SIZE; idx < size; idx++) {
+      for (int idx = 0, size = decoder.getTileWidth() * decoder.getTileHeight(); idx < size; idx++) {
         if ((secData[idx] & ColorConvert.ALPHA_MASK) == 0) {
           priData[idx] = 0;
         }
@@ -1496,7 +1503,7 @@ public class TisConvert {
     } else {
       // replacing transparent pixels on secondary tile with pixels from primary tile
       // removing all opaque pixels on secondary tile
-      for (int idx = 0, size = Config.TILE_SIZE * Config.TILE_SIZE; idx < size; idx++) {
+      for (int idx = 0, size = decoder.getTileWidth() * decoder.getTileHeight(); idx < size; idx++) {
         secData[idx] = ((secData[idx] & ColorConvert.ALPHA_MASK) == 0) ? priData[idx] : 0;
       }
     }
@@ -1534,7 +1541,7 @@ public class TisConvert {
     // performing overlay conversion
     if (isPrimary) {
       // replacing transparent pixels on primary tile with pixels from secondary tile
-      for (int idx = 0, size = Config.TILE_SIZE * Config.TILE_SIZE; idx < size; idx++) {
+      for (int idx = 0, size = decoder.getTileWidth() * decoder.getTileHeight(); idx < size; idx++) {
         if ((priData[idx] & ColorConvert.ALPHA_MASK) == 0) {
           priData[idx] = secData[idx];
         }
@@ -1542,7 +1549,7 @@ public class TisConvert {
     } else {
       // replacing transparent pixels on secondary tile with pixels from primary tile
       // removing all opaque pixels on secondary tile;
-      for (int idx = 0, size = Config.TILE_SIZE * Config.TILE_SIZE; idx < size; idx++) {
+      for (int idx = 0, size = decoder.getTileWidth() * decoder.getTileHeight(); idx < size; idx++) {
         secData[idx] = ((secData[idx] & ColorConvert.ALPHA_MASK) == 0) ? priData[idx] : 0;
       }
     }
@@ -1624,9 +1631,6 @@ public class TisConvert {
    * This class stores global parameters for the tileset conversion operation.
    */
   public static class Config {
-    /** Size of a single tile, in pixels. */
-    public static final int TILE_SIZE = 64;
-
     /** Max. supported texture size, in pixels. */
     public static final int MAX_TEXTURE_SIZE = 1024;
 
@@ -1741,9 +1745,9 @@ public class TisConvert {
       }
       this.defaultTilesPerRow = Math.max(1, Math.min(this.decoder.getTileCount(), defaultTilesPerRow));
       setDefaultRowCount(defaultRowCount);
-      this.textureSize = ensureBinarySize(Math.max(TILE_SIZE, Math.min(MAX_TEXTURE_SIZE, textureSize)));
+      this.textureSize = ensureBinarySize(Math.max(getTileSize(), Math.min(MAX_TEXTURE_SIZE, textureSize)));
       setPvrzBaseIndex(pvrzBaseIndex);
-      this.borderSize = Math.max(0, Math.min(TILE_SIZE, borderSize));
+      this.borderSize = Math.max(0, Math.min(getTileSize(), borderSize));
       setSegmentSize(segmentSize);
       this.detectBlack = detectBlack;
       this.multithreaded = multithreaded;
@@ -1787,6 +1791,11 @@ public class TisConvert {
     /** Returns the assigned {@link TisDecoder} instance. */
     public TisDecoder getDecoder() {
       return decoder;
+    }
+
+    /** Returns the tile dimension obtained from the input TIS header. */
+    public int getTileSize() {
+      return decoder.getTileWidth();
     }
 
     /**
@@ -1847,7 +1856,7 @@ public class TisConvert {
      * conversion.
      */
     public Config setTextureSize(int textureSize) {
-      this.textureSize = ensureBinarySize(Math.max(TILE_SIZE, Math.min(MAX_TEXTURE_SIZE, textureSize)));
+      this.textureSize = ensureBinarySize(Math.max(getTileSize(), Math.min(getMaxTextureSize(), textureSize)));
       return this;
     }
 
@@ -1877,7 +1886,7 @@ public class TisConvert {
      * Palette->PVRZ conversion.
      */
     public Config setBorderSize(int borderSize) {
-      this.borderSize = Math.max(0, Math.min(TILE_SIZE, borderSize));
+      this.borderSize = Math.max(0, Math.min(getTileSize(), borderSize));
       setSegmentSize(getSegmentSize()); // segment size may change
       return this;
     }
@@ -1889,8 +1898,8 @@ public class TisConvert {
 
     /** Sets the max. size of contiguous tile segments, in pixels. */
     public Config setSegmentSize(int segmentSize) {
-      final int minSize = TILE_SIZE + getBorderSize() * 2;
-      this.segmentSize = Math.max(minSize, Math.min(MAX_TEXTURE_SIZE, segmentSize));
+      final int minSize = getTileSize() + getBorderSize() * 2;
+      this.segmentSize = Math.max(minSize, Math.min(getMaxTextureSize(), segmentSize));
       return this;
     }
 
@@ -2789,14 +2798,16 @@ public class TisConvert {
 //        new TreeMap<>((p1, p2) -> (p1.y < p2.y) ? -1 : ((p1.y > p2.y) ? 1 : (p1.x - p2.x)));
     private final Rectangle pageRect = new Rectangle();
     private final WedInfo wedInfo;
+    private final int tileSize;
 
     private int pageIndex;
 
     private Rectangle bounds;
     private int boundsHash;
 
-    public TileMap(WedInfo wedInfo) {
+    public TileMap(WedInfo wedInfo, int tileSize) {
       this.wedInfo = wedInfo;
+      this.tileSize = Math.max(1, tileSize);
       this.pageIndex = -1;
     }
 
@@ -2903,7 +2914,6 @@ public class TisConvert {
      * @return Bounding {@link Rectangle} of the tile map, in pixels.
      */
     public Rectangle getPixelBounds(int borderSize) {
-      final int tileSize = 64;
       borderSize = Math.min(tileSize, Math.max(0, borderSize));
 
       final Rectangle retVal = new Rectangle();
@@ -3091,7 +3101,6 @@ public class TisConvert {
       this.pageRect.width = pageRect.width;
       this.pageRect.height = pageRect.height;
 
-      final int tileSize = 64;
       final Rectangle tileRect = getTileBounds(false);
       final int xOfs = hasLeftBorder() ? borderSize - tileSize : 0;
       final int yOfs = hasTopBorder() ? borderSize - tileSize : 0;
@@ -3203,7 +3212,7 @@ public class TisConvert {
       }
 
       if (tileMap == null) {
-        tileMap = new TileMap(getWedInfo());
+        tileMap = new TileMap(getWedInfo(), tileSize);
       }
 
       if (locations.contains(p)) {

--- a/src/org/infinity/resource/graphics/TisConvert.java
+++ b/src/org/infinity/resource/graphics/TisConvert.java
@@ -230,13 +230,27 @@ public class TisConvert {
         progress.setProgress(0);
       }
 
-      image = ColorConvert.createCompatibleImage(tileCols * 64, tileRows * 64, Transparency.BITMASK);
+      final Image referenceTile = tiles.stream().filter(Objects::nonNull).findFirst().orElse(null);
+      if (referenceTile == null) {
+        return retVal;
+      }
+      final int tileWidth = referenceTile.getWidth(null);
+      final int tileHeight = referenceTile.getHeight(null);
+      if (tileWidth <= 0 || tileHeight <= 0) {
+        return retVal;
+      }
+      final boolean dimensionsValid = tiles.stream().filter(Objects::nonNull)
+          .allMatch(tile -> tile.getWidth(null) == tileWidth && tile.getHeight(null) == tileHeight);
+      if (!dimensionsValid) {
+        return retVal;
+      }
+      image = ColorConvert.createCompatibleImage(tileCols * tileWidth, tileRows * tileHeight, Transparency.BITMASK);
       Graphics2D g = image.createGraphics();
       for (int idx = 0; idx < tiles.size(); idx++) {
         if (tiles.get(idx) != null) {
           int tx = idx % tileCols;
           int ty = idx / tileCols;
-          g.drawImage(tiles.get(idx), tx * 64, ty * 64, null);
+          g.drawImage(tiles.get(idx), tx * tileWidth, ty * tileHeight, null);
         }
       }
       g.dispose();

--- a/src/org/infinity/resource/graphics/TisDecoder.java
+++ b/src/org/infinity/resource/graphics/TisDecoder.java
@@ -23,7 +23,10 @@ public abstract class TisDecoder {
     INVALID, PALETTE, PVRZ
   }
 
-  protected static final int TILE_DIMENSION = 64; // default width and height of a tile
+  /** Default width and height of a tile, in pixels. */
+  public static final int DEFAULT_TILE_DIMENSION = 64;
+  /** Maximum supported width and height of a tile, in pixels. */
+  public static final int MAX_TILE_DIMENSION = 512;
 
   private final ResourceEntry tisEntry;
 
@@ -42,26 +45,8 @@ public abstract class TisDecoder {
    * @return One of the TIS {@code Type}s.
    */
   public static Type getType(ResourceEntry tisEntry) {
-    Type retVal = Type.INVALID;
-    if (tisEntry != null) {
-      try {
-        final boolean ignoreOverride = tisEntry instanceof BIFFResourceEntry;
-        int[] info = tisEntry.getResourceInfo(ignoreOverride);
-        if (info != null && info.length > 1) {
-          if (info[0] > 0 && info[1] > 0) {
-            int sizeV1 = 1024 + TILE_DIMENSION * TILE_DIMENSION;
-            if (sizeV1 == info[1]) {
-              retVal = Type.PALETTE;
-            } else if (info[1] == 12) {
-              retVal = Type.PVRZ;
-            }
-          }
-        }
-      } catch (Exception e) {
-        Logger.error(e);
-      }
-    }
-    return retVal;
+    final TisInfo info = getInfo(tisEntry);
+    return (info != null) ? info.type : Type.INVALID;
   }
 
   /**
@@ -85,7 +70,10 @@ public abstract class TisDecoder {
           int tileSize = StreamUtils.readInt(is);
           is.skip(4); // tile data offset
           int tileDim = StreamUtils.readInt(is);
-          retVal = new TisInfo(numTiles, tileSize, tileDim);
+          final TisInfo info = new TisInfo(numTiles, tileSize, tileDim);
+          if (info.isValid()) {
+            retVal = info;
+          }
         }
       } catch (Exception e) {
         Logger.error(e);
@@ -202,18 +190,34 @@ public abstract class TisDecoder {
     public final Type type;
     /** Number of tiles stored in the TIS file. */
     public final int numTiles;
-    /** Dimension of a TIS tile, in pixels (always 64). */
+    /** Size of a TIS tile record, in bytes. */
+    public final int tileSize;
+    /** Dimension of a square TIS tile, in pixels. */
     public final int tileDimension;
 
     public TisInfo(int numTiles, int tileSize, int tileDim) {
-      this.type = tileSize == 0x0c ? Type.PVRZ : Type.PALETTE;
+      final long paletteTileSize = 1024L + (long)tileDim * tileDim;
+      if (tileSize == 0x0c) {
+        this.type = Type.PVRZ;
+      } else if (tileSize == paletteTileSize) {
+        this.type = Type.PALETTE;
+      } else {
+        this.type = Type.INVALID;
+      }
       this.numTiles = numTiles;
+      this.tileSize = tileSize;
       this.tileDimension = tileDim;
+    }
+
+    /** Returns whether all required header values are valid and mutually consistent. */
+    public boolean isValid() {
+      return type != Type.INVALID && numTiles > 0 && tileDimension > 0 && tileDimension <= MAX_TILE_DIMENSION
+          && (tileDimension & (tileDimension - 1)) == 0;
     }
 
     /** Returns the tile size, in bytes, for the current TIS file. */
     public int getTileSize() {
-      return type == Type.PVRZ ? 0x0c : 0x1400;
+      return tileSize;
     }
   }
 }

--- a/src/org/infinity/resource/graphics/TisResource.java
+++ b/src/org/infinity/resource/graphics/TisResource.java
@@ -1367,7 +1367,8 @@ public class TisResource implements Resource, Closeable, Referenceable, ActionLi
       lBorderSizeLabel.addMouseMotionListener(listeners.mouseMotion);
       helpMap.put(lBorderSizeLabel, helpBorderSize);
 
-      sBorderSize = new JSlider(0, TisConvert.Config.TILE_SIZE, TisConvert.Config.DEFAULT_BORDER_SIZE);
+      final int tileSize = tis.getDecoder().getTileWidth();
+      sBorderSize = new JSlider(0, tileSize, Math.min(tileSize, TisConvert.Config.DEFAULT_BORDER_SIZE));
       sBorderSize.addMouseMotionListener(listeners.mouseMotion);
       sBorderSize.addChangeListener(listeners.changeBorderSize);
       helpMap.put(sBorderSize, helpBorderSize);

--- a/src/org/infinity/resource/graphics/TisResource.java
+++ b/src/org/infinity/resource/graphics/TisResource.java
@@ -622,7 +622,8 @@ public class TisResource implements Resource, Closeable, Referenceable, ActionLi
         defaultWidth = TisConvert.calcTilesetWidth(wedEntry, false, tileCount);
         tileImages = new ArrayList<>(tileCount);
         for (int tileIdx = 0; tileIdx < tileCount; tileIdx++) {
-          BufferedImage image = ColorConvert.createCompatibleImage(64, 64, Transparency.BITMASK);
+          BufferedImage image = ColorConvert.createCompatibleImage(decoder.getTileWidth(), decoder.getTileHeight(),
+              Transparency.BITMASK);
           decoder.getTile(tileIdx, image);
           tileImages.add(image);
         }
@@ -868,7 +869,7 @@ public class TisResource implements Resource, Closeable, Referenceable, ActionLi
     public TisPreview(TisDecoder decoder, int tileSize, Color splitColor, Object renderingHints)
         throws Exception {
       this.decoder = Objects.requireNonNull(decoder);
-      this.tileSize = Math.max(1, Math.min(64, tileSize));
+      this.tileSize = Math.max(1, Math.min(decoder.getTileWidth(), tileSize));
       this.splitColor = (splitColor != null) ? splitColor : DEF_SPLIT_COLOR;
       this.renderingHints = validateRenderingHints(renderingHints);
       init();
@@ -886,7 +887,7 @@ public class TisResource implements Resource, Closeable, Referenceable, ActionLi
 
     /** Sets the preview tile size, in pixels. Forces the preview tiles to be recreated. */
     public TisPreview setTileSize(int tileSize) throws Exception {
-      tileSize = Math.max(1, Math.min(64, tileSize));
+      tileSize = Math.max(1, Math.min(getDecoder().getTileWidth(), tileSize));
       if (tileSize != this.tileSize) {
         this.tileSize = tileSize;
         init();
@@ -1010,8 +1011,11 @@ public class TisResource implements Resource, Closeable, Referenceable, ActionLi
     private void init() throws Exception {
       tiles.clear();
 
-      final AffineTransform xform = AffineTransform.getScaleInstance(tileSize / 64.0, tileSize / 64.0);
-      final BufferedImage tileImg = ColorConvert.createCompatibleImage(64, 64, true);
+      final int tileWidth = getDecoder().getTileWidth();
+      final int tileHeight = getDecoder().getTileHeight();
+      final AffineTransform xform = AffineTransform.getScaleInstance(tileSize / (double)tileWidth,
+          tileSize / (double)tileHeight);
+      final BufferedImage tileImg = ColorConvert.createCompatibleImage(tileWidth, tileHeight, true);
 
       for (int idx = 0, size = getDecoder().getTileCount(); idx < size; idx++) {
         getDecoder().getTile(idx, tileImg);

--- a/src/org/infinity/resource/graphics/TisV1Decoder.java
+++ b/src/org/infinity/resource/graphics/TisV1Decoder.java
@@ -13,7 +13,6 @@ import java.awt.image.DataBufferInt;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
-import org.infinity.resource.key.BIFFResourceEntry;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.util.Logger;
 
@@ -26,6 +25,7 @@ public class TisV1Decoder extends TisDecoder {
   private ByteBuffer tisBuffer;
   private int tileCount;
   private int tileSize;
+  private int tileDimension;
   private int[] workingPalette;
   private BufferedImage workingCanvas;
 
@@ -88,7 +88,7 @@ public class TisV1Decoder extends TisDecoder {
    */
   public byte[] getRawTileData(int tileIdx) {
     if (tileIdx >= 0 && tileIdx < getTileCount()) {
-      byte[] buffer = new byte[TILE_DIMENSION * TILE_DIMENSION];
+      byte[] buffer = new byte[tileDimension * tileDimension];
       getRawTileData(tileIdx, buffer);
       return buffer;
     } else {
@@ -106,7 +106,7 @@ public class TisV1Decoder extends TisDecoder {
     if (buffer != null) {
       int ofs = getTileOffset(tileIdx);
       if (ofs > 0) {
-        int maxSize = Math.min(buffer.length, TILE_DIMENSION * TILE_DIMENSION);
+        int maxSize = Math.min(buffer.length, tileDimension * tileDimension);
         ofs += 4 * 256; // skipping palette data
         tisBuffer.position(ofs);
         tisBuffer.get(buffer, 0, maxSize);
@@ -119,6 +119,7 @@ public class TisV1Decoder extends TisDecoder {
     tisBuffer = null;
     tileCount = 0;
     tileSize = 0;
+    tileDimension = 0;
     workingPalette = null;
     if (workingCanvas != null) {
       workingCanvas.flush();
@@ -138,12 +139,12 @@ public class TisV1Decoder extends TisDecoder {
 
   @Override
   public int getTileWidth() {
-    return TILE_DIMENSION;
+    return tileDimension;
   }
 
   @Override
   public int getTileHeight() {
-    return TILE_DIMENSION;
+    return tileDimension;
   }
 
   @Override
@@ -153,7 +154,7 @@ public class TisV1Decoder extends TisDecoder {
 
   @Override
   public Image getTile(int tileIdx) {
-    BufferedImage image = ColorConvert.createCompatibleImage(TILE_DIMENSION, TILE_DIMENSION, true);
+    BufferedImage image = ColorConvert.createCompatibleImage(tileDimension, tileDimension, true);
     renderTile(tileIdx, image);
     return image;
   }
@@ -165,7 +166,7 @@ public class TisV1Decoder extends TisDecoder {
 
   @Override
   public int[] getTileData(int tileIdx) {
-    int[] buffer = new int[TILE_DIMENSION * TILE_DIMENSION];
+    int[] buffer = new int[tileDimension * tileDimension];
     renderTile(tileIdx, buffer);
     return buffer;
   }
@@ -180,26 +181,20 @@ public class TisV1Decoder extends TisDecoder {
 
     if (getResourceEntry() != null) {
       try {
-        final boolean ignoreOverride = getResourceEntry() instanceof BIFFResourceEntry;
-        int[] info = getResourceEntry().getResourceInfo(ignoreOverride);
-        if (info == null || info.length < 2) {
+        final TisInfo info = TisDecoder.getInfo(getResourceEntry());
+        if (info == null || info.type != Type.PALETTE) {
           throw new Exception("Error reading TIS header");
         }
 
-        tileCount = info[0];
-        if (tileCount <= 0) {
-          throw new Exception("Invalid tile count: " + tileCount);
-        }
-        tileSize = info[1];
-        if (tileSize != 1024 + TILE_DIMENSION * TILE_DIMENSION) {
-          throw new Exception("Invalid tile size: " + tileSize);
-        }
+        tileCount = info.numTiles;
+        tileSize = info.tileSize;
+        tileDimension = info.tileDimension;
         tisBuffer = getResourceEntry().getResourceBuffer();
 
         setType(Type.PALETTE);
 
         workingPalette = new int[256];
-        workingCanvas = new BufferedImage(TILE_DIMENSION, TILE_DIMENSION, Transparency.BITMASK);
+        workingCanvas = new BufferedImage(tileDimension, tileDimension, Transparency.BITMASK);
       } catch (Exception e) {
         Logger.error(e);
         close();
@@ -218,7 +213,7 @@ public class TisV1Decoder extends TisDecoder {
 
   // Paints the specified tile onto the canvas
   private boolean renderTile(int tileIdx, Image canvas) {
-    if (canvas != null && canvas.getWidth(null) >= TILE_DIMENSION && canvas.getHeight(null) >= TILE_DIMENSION) {
+    if (canvas != null && canvas.getWidth(null) >= tileDimension && canvas.getHeight(null) >= tileDimension) {
       int[] buffer = ((DataBufferInt) workingCanvas.getRaster().getDataBuffer()).getData();
       if (renderTile(tileIdx, buffer)) {
         buffer = null;
@@ -226,7 +221,7 @@ public class TisV1Decoder extends TisDecoder {
         try {
           g.setComposite(AlphaComposite.Src);
           g.setColor(ColorConvert.TRANSPARENT_COLOR);
-          g.fillRect(0, 0, TILE_DIMENSION, TILE_DIMENSION);
+          g.fillRect(0, 0, tileDimension, tileDimension);
           g.drawImage(workingCanvas, 0, 0, null);
         } finally {
           g.dispose();
@@ -241,7 +236,7 @@ public class TisV1Decoder extends TisDecoder {
 
   // Writes the specified tile data into the buffer
   private boolean renderTile(int tileIdx, int[] buffer) {
-    int size = TILE_DIMENSION * TILE_DIMENSION;
+    int size = tileDimension * tileDimension;
     if (buffer != null && buffer.length >= size) {
       int ofs = getTileOffset(tileIdx);
       if (ofs > 0) {
@@ -260,7 +255,7 @@ public class TisV1Decoder extends TisDecoder {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + Objects.hash(tileCount, tileSize, tisBuffer);
+    result = prime * result + Objects.hash(tileCount, tileSize, tileDimension, tisBuffer);
     return result;
   }
 
@@ -276,12 +271,13 @@ public class TisV1Decoder extends TisDecoder {
       return false;
     }
     TisV1Decoder other = (TisV1Decoder)obj;
-    return tileCount == other.tileCount && tileSize == other.tileSize && Objects.equals(tisBuffer, other.tisBuffer);
+    return tileCount == other.tileCount && tileSize == other.tileSize && tileDimension == other.tileDimension
+        && Objects.equals(tisBuffer, other.tisBuffer);
   }
 
   @Override
   public String toString() {
     return "TisV1Decoder [type=" + getType() + ", tisEntry=" + getResourceEntry() + ", tileCount=" + tileCount
-        + ", tileSize=" + tileSize + "]";
+        + ", tileSize=" + tileSize + ", tileDimension=" + tileDimension + "]";
   }
 }

--- a/src/org/infinity/resource/graphics/TisV2Decoder.java
+++ b/src/org/infinity/resource/graphics/TisV2Decoder.java
@@ -14,7 +14,6 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 
 import org.infinity.resource.ResourceFactory;
-import org.infinity.resource.key.BIFFResourceEntry;
 import org.infinity.resource.key.ResourceEntry;
 import org.infinity.util.Logger;
 
@@ -27,6 +26,7 @@ public class TisV2Decoder extends TisDecoder {
   private ByteBuffer tisBuffer;
   private int tileCount;
   private int tileSize;
+  private int tileDimension;
   private String pvrzNameBase;
   private BufferedImage workingCanvas;
 
@@ -81,6 +81,7 @@ public class TisV2Decoder extends TisDecoder {
     tisBuffer = null;
     tileCount = 0;
     tileSize = 0;
+    tileDimension = 0;
     pvrzNameBase = "";
     if (workingCanvas != null) {
       workingCanvas.flush();
@@ -100,12 +101,12 @@ public class TisV2Decoder extends TisDecoder {
 
   @Override
   public int getTileWidth() {
-    return TILE_DIMENSION;
+    return tileDimension;
   }
 
   @Override
   public int getTileHeight() {
-    return TILE_DIMENSION;
+    return tileDimension;
   }
 
   @Override
@@ -115,7 +116,7 @@ public class TisV2Decoder extends TisDecoder {
 
   @Override
   public Image getTile(int tileIdx) {
-    BufferedImage image = ColorConvert.createCompatibleImage(TILE_DIMENSION, TILE_DIMENSION, true);
+    BufferedImage image = ColorConvert.createCompatibleImage(tileDimension, tileDimension, true);
     renderTile(tileIdx, image);
     return image;
   }
@@ -127,7 +128,7 @@ public class TisV2Decoder extends TisDecoder {
 
   @Override
   public int[] getTileData(int tileIdx) {
-    int[] buffer = new int[TILE_DIMENSION * TILE_DIMENSION];
+    int[] buffer = new int[tileDimension * tileDimension];
     renderTile(tileIdx, buffer);
     return buffer;
   }
@@ -142,20 +143,14 @@ public class TisV2Decoder extends TisDecoder {
 
     if (getResourceEntry() != null) {
       try {
-        final boolean ignoreOverride = getResourceEntry() instanceof BIFFResourceEntry;
-        int[] info = getResourceEntry().getResourceInfo(ignoreOverride);
-        if (info == null || info.length < 2) {
+        final TisInfo info = TisDecoder.getInfo(getResourceEntry());
+        if (info == null || info.type != Type.PVRZ) {
           throw new Exception("Error reading TIS header");
         }
 
-        tileCount = info[0];
-        if (tileCount <= 0) {
-          throw new Exception("Invalid tile count: " + tileCount);
-        }
-        tileSize = info[1];
-        if (tileSize != 12) {
-          throw new Exception("Invalid tile size: " + tileSize);
-        }
+        tileCount = info.numTiles;
+        tileSize = info.tileSize;
+        tileDimension = info.tileDimension;
         tisBuffer = getResourceEntry().getResourceBuffer();
 
         String name = getResourceEntry().getResourceRef();
@@ -164,7 +159,7 @@ public class TisV2Decoder extends TisDecoder {
 
         setType(Type.PVRZ);
 
-        workingCanvas = new BufferedImage(TILE_DIMENSION, TILE_DIMENSION, BufferedImage.TYPE_INT_ARGB);
+        workingCanvas = new BufferedImage(tileDimension, tileDimension, BufferedImage.TYPE_INT_ARGB);
       } catch (Exception e) {
         Logger.error(e);
         close();
@@ -197,7 +192,7 @@ public class TisV2Decoder extends TisDecoder {
 
   // Paints the specified tile onto the canvas
   private boolean renderTile(int tileIdx, Image canvas) {
-    if (canvas != null && canvas.getWidth(null) >= TILE_DIMENSION && canvas.getHeight(null) >= TILE_DIMENSION) {
+    if (canvas != null && canvas.getWidth(null) >= tileDimension && canvas.getHeight(null) >= tileDimension) {
       if (updateWorkingCanvas(tileIdx)) {
         Graphics2D g = (Graphics2D) canvas.getGraphics();
         try {
@@ -215,7 +210,7 @@ public class TisV2Decoder extends TisDecoder {
 
   // Writes the specified tile data into the buffer
   private boolean renderTile(int tileIdx, int[] buffer) {
-    int size = TILE_DIMENSION * TILE_DIMENSION;
+    int size = tileDimension * tileDimension;
     if (buffer != null && buffer.length >= size) {
       if (updateWorkingCanvas(tileIdx)) {
         int[] src = ((DataBufferInt) workingCanvas.getRaster().getDataBuffer()).getData();
@@ -242,14 +237,14 @@ public class TisV2Decoder extends TisDecoder {
             Graphics2D g = workingCanvas.createGraphics();
             try {
               g.setColor(Color.BLACK);
-              g.fillRect(0, 0, TILE_DIMENSION, TILE_DIMENSION);
+              g.fillRect(0, 0, tileDimension, tileDimension);
             } finally {
               g.dispose();
               g = null;
             }
           } else {
             // drawing new content
-            decoder.decode(workingCanvas, x, y, TILE_DIMENSION, TILE_DIMENSION);
+            decoder.decode(workingCanvas, x, y, tileDimension, tileDimension);
             decoder = null;
           }
           return true;
@@ -265,7 +260,7 @@ public class TisV2Decoder extends TisDecoder {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + Objects.hash(pvrzNameBase, tileCount, tileSize, tisBuffer);
+    result = prime * result + Objects.hash(pvrzNameBase, tileCount, tileSize, tileDimension, tisBuffer);
     return result;
   }
 
@@ -282,12 +277,14 @@ public class TisV2Decoder extends TisDecoder {
     }
     TisV2Decoder other = (TisV2Decoder)obj;
     return Objects.equals(pvrzNameBase, other.pvrzNameBase) && tileCount == other.tileCount
-        && tileSize == other.tileSize && Objects.equals(tisBuffer, other.tisBuffer);
+        && tileSize == other.tileSize && tileDimension == other.tileDimension
+        && Objects.equals(tisBuffer, other.tisBuffer);
   }
 
   @Override
   public String toString() {
     return "TisV2Decoder [type=" + getType() + ", tisEntry=" + getResourceEntry() + ", tileCount=" + tileCount
-        + ", tileSize=" + tileSize + ", pvrzNameBase=" + pvrzNameBase + "]";
+        + ", tileSize=" + tileSize + ", tileDimension=" + tileDimension + ", pvrzNameBase=" + pvrzNameBase
+        + "]";
   }
 }

--- a/src/org/infinity/resource/key/BIFFWriter.java
+++ b/src/org/infinity/resource/key/BIFFWriter.java
@@ -20,12 +20,16 @@ import java.util.zip.DeflaterOutputStream;
 
 import org.infinity.resource.Profile;
 import org.infinity.resource.ResourceFactory;
+import org.infinity.resource.graphics.TisDecoder;
 import org.infinity.util.Logger;
 import org.infinity.util.io.FileEx;
 import org.infinity.util.io.FileManager;
 import org.infinity.util.io.StreamUtils;
 
 public final class BIFFWriter {
+  private static final String TIS_SIGNATURE_VERSION = "TIS V1  ";
+  private static final int TIS_TILE_DIMENSION_OFFSET = 0x14;
+
   private final BIFFEntry bifEntry;
   private final Map<ResourceEntry, Boolean> resources = new HashMap<>();
   private final Map<ResourceEntry, Boolean> tileResources = new HashMap<>();
@@ -107,9 +111,33 @@ public final class BIFFWriter {
 
   public void addResource(ResourceEntry resourceEntry, boolean ignoreoverride) {
     if (resourceEntry.getExtension().equalsIgnoreCase("TIS")) {
+      validateResource(resourceEntry, ignoreoverride);
       tileResources.put(resourceEntry, ignoreoverride);
     } else {
       resources.put(resourceEntry, ignoreoverride);
+    }
+  }
+
+  public static void validateResource(ResourceEntry resourceEntry, boolean ignoreOverride) {
+    if (!resourceEntry.getExtension().equalsIgnoreCase("TIS")) {
+      return;
+    }
+    try (InputStream is = resourceEntry.getResourceDataAsStream(ignoreOverride)) {
+      final int bytesToSkip = TIS_TILE_DIMENSION_OFFSET - TIS_SIGNATURE_VERSION.length();
+      if (TIS_SIGNATURE_VERSION.equals(StreamUtils.readString(is, TIS_SIGNATURE_VERSION.length()))
+          && is.skip(bytesToSkip) == bytesToSkip) {
+        final int tileDimension = StreamUtils.readInt(is);
+        if (tileDimension != TisDecoder.DEFAULT_TILE_DIMENSION) {
+          throw new IllegalArgumentException("Cannot add " + resourceEntry.getResourceName()
+              + " to a BIFF archive: tile dimension " + tileDimension
+              + " is not supported. BIFF archives require " + TisDecoder.DEFAULT_TILE_DIMENSION + "x"
+              + TisDecoder.DEFAULT_TILE_DIMENSION + " pixel TIS tiles.");
+        }
+      }
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Could not validate " + resourceEntry.getResourceName(), e);
     }
   }
 


### PR DESCRIPTION
 ## Summary

  Completes support for nonstandard TIS tile dimensions by removing remaining hardcoded 64×64 assumptions from TIS
  conversion and Area Viewer code.

  This cannot be loaded at all without my [modification ](https://github.com/TheForgotten69/InfinityEngine-Enhancer) and already in used with my [upscale mod](https://www.nexusmods.com/baldursgate/mods/105?tab=description). As I'm working on a newer version and more engine/graphics modification, I feel it's the right time to upstream this.

I'll put it as draft as I reworked a bit the code and I haven't fully test everything atm.

  ## Changes
  - Use the decoded dimensions for:
    - palette tile records and pixel buffers
    - PVRZ texture packing and rendering
    - border calculations
    - overlay conversion
    - black-tile detection
    - generated TIS headers
  - Preserve the WED area's logical 64×64 map grid.
  - Scale larger authored tiles into 64×64 Area Viewer cells.
  - Update the conversion dialog's border-size range for the decoded tile dimension.

  - Verified that no authored-pixel 64×64 assumptions remain in `TisConvert`.
  
  
  
  TLDR: the TIS header store the actual tile size (which can be non standard 64x64).For a 256×256 TIS, the offset 0x14 tile dimension:
  - before: 0x40  (64)
 -  after:  0x100 (256)