### PR TITLE
Default new ITM equipped effects to self and while equipped

### DIFF
--- a/src/org/infinity/datatype/EffectType.java
+++ b/src/org/infinity/datatype/EffectType.java
@@ -20,6 +20,8 @@ public final class EffectType extends Bitmap implements UpdateListener {
   public static final String EFFECT_TYPE_TARGET = "Target";
   public static final String EFFECT_TYPE_POWER  = "Power";
 
+  public static final int TARGET_SELF = 1;
+
   private static final String[] TARGET_ARRAY = { "None", "Self", "Preset target", "Party", "Everyone",
       "Everyone except party", "Caster group", "Target group", "Everyone except self", "Original caster" };
 

--- a/src/org/infinity/resource/Effect.java
+++ b/src/org/infinity/resource/Effect.java
@@ -9,17 +9,25 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.infinity.datatype.AbstractBitmap;
 import org.infinity.datatype.DecNumber;
 import org.infinity.datatype.EffectType;
 import org.infinity.resource.effects.BaseOpcode;
+import org.infinity.resource.itm.ItmResource;
 import org.infinity.util.io.StreamUtils;
 
 public final class Effect extends AbstractStruct implements AddRemovable {
   // Effect-specific field labels
   public static final String EFFECT = "Effect";
 
+  private static final int TARGET_SELF = 1;
+  private static final int TIMING_MODE_INSTANT_WHILE_EQUIPPED = 2;
+
+  private boolean isNew;
+
   public Effect() throws Exception {
     super(null, EFFECT, StreamUtils.getByteBuffer(48), 0);
+    isNew = true;
     ((DecNumber) getAttribute(BaseOpcode.EFFECT_PROBABILITY_1)).setValue(100);
   }
 
@@ -39,6 +47,18 @@ public final class Effect extends AbstractStruct implements AddRemovable {
   }
 
   // --------------------- End Interface AddRemovable ---------------------
+
+  @Override
+  public void setParent(AbstractStruct parent) {
+    if (isNew && parent != null) {
+      if (parent instanceof ItmResource) {
+        setBitmapValue(EffectType.EFFECT_TYPE_TARGET, TARGET_SELF);
+        setBitmapValue(BaseOpcode.EFFECT_TIMING_MODE, TIMING_MODE_INSTANT_WHILE_EQUIPPED);
+      }
+      isNew = false;
+    }
+    super.setParent(parent);
+  }
 
   @Override
   public int read(ByteBuffer buffer, int offset) throws Exception {
@@ -120,5 +140,29 @@ public final class Effect extends AbstractStruct implements AddRemovable {
     }
 
     return retVal;
+  }
+
+  private void setBitmapValue(String attributeName, int value) {
+    final StructEntry entry = getAttribute(attributeName);
+    if (!(entry instanceof AbstractBitmap<?>)) {
+      throw new IllegalStateException("Effect attribute is not a bitmap: " + attributeName);
+    }
+
+    final AbstractBitmap<?> bitmap = (AbstractBitmap<?>) entry;
+    final ByteBuffer buffer = StreamUtils.getByteBuffer(bitmap.getSize());
+    switch (bitmap.getSize()) {
+      case 1:
+        buffer.put((byte) value);
+        break;
+      case 2:
+        buffer.putShort((short) value);
+        break;
+      case 4:
+        buffer.putInt(value);
+        break;
+      default:
+        throw new IllegalStateException("Unsupported bitmap size: " + bitmap.getSize());
+    }
+    bitmap.read(buffer, 0);
   }
 }

--- a/src/org/infinity/resource/Effect.java
+++ b/src/org/infinity/resource/Effect.java
@@ -20,7 +20,6 @@ public final class Effect extends AbstractStruct implements AddRemovable {
   // Effect-specific field labels
   public static final String EFFECT = "Effect";
 
-  private static final int TARGET_SELF = 1;
   private static final int TIMING_MODE_INSTANT_WHILE_EQUIPPED = 2;
 
   private boolean isNew;
@@ -52,7 +51,7 @@ public final class Effect extends AbstractStruct implements AddRemovable {
   public void setParent(AbstractStruct parent) {
     if (isNew && parent != null) {
       if (parent instanceof ItmResource) {
-        setBitmapValue(EffectType.EFFECT_TYPE_TARGET, TARGET_SELF);
+        setBitmapValue(EffectType.EFFECT_TYPE_TARGET, EffectType.TARGET_SELF);
         setBitmapValue(BaseOpcode.EFFECT_TIMING_MODE, TIMING_MODE_INSTANT_WHILE_EQUIPPED);
       }
       isNew = false;


### PR DESCRIPTION
## Summary

This change updates newly created global ITM effects so that they default to the values appropriate for equipped effects:

- **Target:** `Self` (`1`)
- **Timing mode:** `Instant/While equipped` (`2`)

The defaults are applied only when a newly created `Effect` is attached directly to an `ItmResource`.

## Implementation

- Add the named `EffectType.TARGET_SELF` constant for the existing target value `1`.
- Track whether an `Effect` originated from the new-effect constructor.
- Apply the equipped-effect defaults when that new effect is first assigned directly to an `ItmResource`.
- Set bitmap-backed attributes through their datatype representation rather than relying on raw effect-buffer offsets.
- Preserve the existing default probability of `100`.

## Scope and compatibility

The change deliberately does **not** modify:

- effects loaded from existing ITM resources;
- effects belonging to an ITM ability;
- newly created SPL effects;
- existing serialized effect values;
- EFF V2 effects.

This keeps the behavior limited to the global/equipped-effect creation path in ITM resources.

## Validation

A disposable GitHub Actions workflow was used to validate the change:

- compiled all 1,230 Java source files with the project Ant build;
- inspected the generated `Effect` bytecode;
- verified new-effect and loaded-effect constructor invariants;
- verified direct `ItmResource` parent scoping;
- verified the named target and timing-mode mappings;
- verified the required defaulting and parent-assignment order.

Successful workflow run:

https://github.com/4Luke4/NearInfinity/actions/runs/30743710291

The temporary workflow and all CI-only commits were removed from the feature branch after validation.