### PR TITLE
Improve IntelliJ project baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ jar/NearInfinity.jar
 *.class
 /bin
 /build
-/.idea
+/.idea/*
+!/.idea/libraries/
+!/.idea/modules.xml
 /.settings
 .vscode/launch.json

--- a/.idea/libraries/apng_writer_core.xml
+++ b/.idea/libraries/apng_writer_core.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="apng-writer-core">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/apng-writer/apng-writer-core.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/apng-writer/apng-writer-core-src.zip!/src/main/java" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/commonmark_0_21_0.xml
+++ b/.idea/libraries/commonmark_0_21_0.xml
@@ -1,0 +1,31 @@
+<component name="libraryTable">
+  <library name="commonmark-0.21.0">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-0.21.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-autolink/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-autolink/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-gfm-strikethrough/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-gfm-strikethrough/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-gfm-tables/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-gfm-tables/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-heading-anchor/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-heading-anchor/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-image-attributes/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-image-attributes/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-ins/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-ins/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-task-list-items/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-task-list-items/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-yaml-front-matter/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-ext-yaml-front-matter/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-integration-test/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-integration-test/src/test/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark-test-util/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/commonmark-java-commonmark-parent-0.21.0/commonmark/src/test/java" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/flatlaf_3_6.xml
+++ b/.idea/libraries/flatlaf_3_6.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="flatlaf-3.6">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/flatlaf/flatlaf-3.6.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$PROJECT_DIR$/lib/flatlaf/flatlaf-3.6-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/flatlaf/flatlaf-3.6-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/flatlaf_intellij_themes_3_6.xml
+++ b/.idea/libraries/flatlaf_intellij_themes_3_6.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="flatlaf-intellij-themes-3.6">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/flatlaf/flatlaf-intellij-themes-3.6.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$PROJECT_DIR$/lib/flatlaf/flatlaf-intellij-themes-3.6-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/flatlaf/flatlaf-intellij-themes-3.6-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/javacc.xml
+++ b/.idea/libraries/javacc.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="javacc">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/javacc/javacc.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/jhexview.xml
+++ b/.idea/libraries/jhexview.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="jhexview">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/jhexview/jhexview.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/jorbis.xml
+++ b/.idea/libraries/jorbis.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="jorbis">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/jorbis/jorbis.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/jorbis/jorbis-0.0.17.zip!/jorbis-0.0.17" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/json_20250517.xml
+++ b/.idea/libraries/json_20250517.xml
@@ -1,0 +1,12 @@
+<component name="libraryTable">
+  <library name="json-20250517">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/json/json-20250517.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/json/JSON-java-20250517.zip!/JSON-java-20250517/src/main/java" />
+      <root url="jar://$PROJECT_DIR$/lib/json/JSON-java-20250517.zip!/JSON-java-20250517/src/test/java" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/montemedia.xml
+++ b/.idea/libraries/montemedia.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="montemedia">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/montemedia/montemedia.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/montemedia/MonteMedia-0.7.7.zip!/MonteMedia-0.7.7/src" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/rsyntaxtextarea.xml
+++ b/.idea/libraries/rsyntaxtextarea.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="rsyntaxtextarea">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/rsyntaxtextarea/rsyntaxtextarea.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/rsyntaxtextarea/rsyntaxtextarea-3.6.1-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/tinylog_api_2_7_0.xml
+++ b/.idea/libraries/tinylog_api_2_7_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="tinylog-api-2.7.0">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/tinylog/tinylog-api-2.7.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/tinylog/tinylog-api-2.7.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/tinylog_impl_2_7_0.xml
+++ b/.idea/libraries/tinylog_impl_2_7_0.xml
@@ -1,0 +1,11 @@
+<component name="libraryTable">
+  <library name="tinylog-impl-2.7.0">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/tinylog/tinylog-impl-2.7.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/tinylog/tinylog-impl-2.7.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/NearInfinity.iml" filepath="$PROJECT_DIR$/NearInfinity.iml" />
+    </modules>
+  </component>
+</project>

--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1788644787985</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/NearInfinity.iml
+++ b/NearInfinity.iml
@@ -1,163 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="EclipseModuleManager">
-    <libelement value="jar://$MODULE_DIR$/lib/jorbis/jorbis.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/rsyntaxtextarea/rsyntaxtextarea.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/jhexview/jhexview.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/montemedia/montemedia.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/apng-writer/apng-writer-core.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/json/json-20230227.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/commonmark/commonmark-0.21.0.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-3.4.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-intellij-themes-3.4.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/tinylog/tinylog-api-2.7.0.jar!/" />
-    <libelement value="jar://$MODULE_DIR$/lib/tinylog/tinylog-impl-2.7.0.jar!/" />
-    <src_description expected_position="0">
-      <src_folder value="file://$MODULE_DIR$/src" expected_position="0" />
-    </src_description>
-  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
     </content>
-    <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library" exported="">
-      <library name="jorbis.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/jorbis/jorbis.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/jorbis/jorbis-0.0.17.zip!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="rsyntaxtextarea.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/rsyntaxtextarea/rsyntaxtextarea.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/rsyntaxtextarea/rsyntaxtextarea-3.4.0-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="jhexview.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/jhexview/jhexview.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="file://lib/jhexview/jhexview-current.zip" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="montemedia.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/montemedia/montemedia.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/montemedia/MonteMedia-0.7.7.zip!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="apng-writer-core.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/apng-writer/apng-writer-core.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/apng-writer/apng-writer-core-src.zip!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="json-20230227.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/json/json-20230227.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/json/JSON-java-20230227.zip!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="commonmark-0.21.0.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/commonmark/commonmark-0.21.0.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/commonmark/commonmark-java-commonmark-parent-0.21.0.zip!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="flatlaf-3.4.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-3.4.jar!/" />
-        </CLASSES>
-        <JAVADOC>
-          <root url="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-3.4-javadoc.jar!/" />
-        </JAVADOC>
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-3.4-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="flatlaf-intellij-themes-3.4.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-intellij-themes-3.4.jar!/" />
-        </CLASSES>
-        <JAVADOC>
-          <root url="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-intellij-themes-3.4-javadoc.jar!/" />
-        </JAVADOC>
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/flatlaf/flatlaf-intellij-themes-3.4-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="tinylog-api-2.7.0.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/tinylog/tinylog-api-2.7.0.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/tinylog/tinylog-api-2.7.0-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library" exported="">
-      <library name="tinylog-impl-2.7.0.jar">
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/tinylog/tinylog-impl-2.7.0.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/tinylog/tinylog-impl-2.7.0-sources.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
     <orderEntry type="inheritedJdk" />
-    <orderEntry type="library" name="tinylog-impl-2.7.0" level="project" />
-    <orderEntry type="library" name="tinylog-impl-2.7.1" level="project" />
-    <orderEntry type="library" name="jorbis" level="project" />
-    <orderEntry type="library" name="rsyntaxtextarea" level="project" />
-    <orderEntry type="library" name="jhexview" level="project" />
-    <orderEntry type="library" name="montemedia" level="project" />
+    <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="apng-writer-core" level="project" />
-    <orderEntry type="library" name="json-20250517" level="project" />
     <orderEntry type="library" name="commonmark-0.21.0" level="project" />
     <orderEntry type="library" name="flatlaf-3.6" level="project" />
     <orderEntry type="library" name="flatlaf-intellij-themes-3.6" level="project" />
+    <orderEntry type="library" name="javacc" level="project" />
+    <orderEntry type="library" name="jhexview" level="project" />
+    <orderEntry type="library" name="jorbis" level="project" />
+    <orderEntry type="library" name="json-20250517" level="project" />
+    <orderEntry type="library" name="montemedia" level="project" />
+    <orderEntry type="library" name="rsyntaxtextarea" level="project" />
+    <orderEntry type="library" name="tinylog-api-2.7.0" level="project" />
+    <orderEntry type="library" name="tinylog-impl-2.7.0" level="project" />
   </component>
 </module>


### PR DESCRIPTION
This pull request improves the baseline IntelliJ files included with Near Infinity to help get things up and running faster after cloning the repo. I've made sure the included files don't include any machine-specific configuration.

After cloning the repo and opening the folder as an IntelliJ project, you still have to do the following to finalize the configuration:
1) Navigate to `File -> Project Structure...`.
2) Set `Project -> SDK` to your machine's JDK. You might have to add a new JDK under the `SDKs` tab first. 
3) Set `Project -> Language level` to `8`.
4) Set `Project -> Compiler output` to `<absolute repo path>/build`.